### PR TITLE
Expand the set of media notes that can be parsed to handle the real world data

### DIFF
--- a/tests/test_media_extractor.py
+++ b/tests/test_media_extractor.py
@@ -1,6 +1,6 @@
 """Unit tests for the media entry extraction functionality."""
 
-from preprocessing.media_extractor import extract_entries
+from preprocessing.media_extractor import extract_entries, IGNORED_VERBS
 
 
 def test_extract_single_entry():
@@ -67,6 +67,7 @@ def test_single_week_action_phrasings():
         ("Read Lord of the Rings", "Lord of the Rings"),
         ("Watched Succession", "Succession"),
         ("Played Cyberpunk 2077", "Cyberpunk 2077"),
+        ("Explored Sentry", "Sentry"),
     ]
 
     for raw_text, expected_title in test_cases:
@@ -100,3 +101,88 @@ def test_empty_or_invalid_record():
 
     entries = extract_entries(record)
     assert len(entries) == 0
+
+
+def test_ignored_actions():
+    """Test ignoring actions from data that we don't care about."""
+
+    for verb in IGNORED_VERBS:
+        record = {
+            "start_date": "2023-04-01",
+            "end_date": "2023-04-07",
+            "raw_notes": f"{verb} a birthday",
+        }
+
+        entries = extract_entries(record)
+
+    assert len(entries) == 0
+
+
+def test_ignored_actions_after_2025(caplog):
+    """Test actions aren't ignored after 2025 so they can be reviewed."""
+    for verb in IGNORED_VERBS:
+        record = {
+            "start_date": "2025-01-01",
+            "end_date": "2025-01-07",
+            "raw_notes": f"{verb} a birthday",
+        }
+
+        entries = extract_entries(record)
+
+        assert (
+            f"Skipping line with invalid action '{verb}': {record['raw_notes']}"
+            in caplog.text
+        )
+        assert len(entries) == 0
+
+
+def test_action_mapping_typo():
+    """Test that action mapping is correct for the finshed typo."""
+    record = {
+        "start_date": "2023-05-01",
+        "end_date": "2023-05-07",
+        "raw_notes": "Finshed The Witcher 3",
+    }
+
+    entries = extract_entries(record)
+
+    assert len(entries) == 1
+    assert entries[0]["action"] == "finished"
+    assert entries[0]["title"] == "The Witcher 3"
+    assert entries[0]["date"] == "2023-05-01"
+
+
+def test_action_mapping_restarted():
+    """Test that action mapping is correct for different ways of saying restarted."""
+    for verb in ("Good", "Restarted", "Resumed"):
+        record = {
+            "start_date": "2023-05-01",
+            "end_date": "2023-05-07",
+            "raw_notes": f"{verb} The Witcher 3",
+        }
+
+        entries = extract_entries(record)
+
+        assert len(entries) == 1
+        assert entries[0]["action"] == "started"
+        assert entries[0]["title"] == "The Witcher 3"
+        assert entries[0]["date"] == "2023-05-01"
+
+
+def test_action_continuing_line():
+    """Test that the action is continued from the previous line with "&"."""
+    record = {
+        "start_date": "2023-06-01",
+        "end_date": "2023-06-07",
+        "raw_notes": "Finished The Witcher 3\n& Frostpunk",
+    }
+
+    entries = extract_entries(record)
+
+    assert len(entries) == 2
+    assert entries[0]["action"] == "finished"
+    assert entries[0]["title"] == "The Witcher 3"
+    assert entries[0]["date"] == "2023-06-01"
+    assert entries[1]["action"] == "finished"
+    assert entries[1]["title"] == "Frostpunk"
+    assert entries[1]["date"] == "2023-06-01"


### PR DESCRIPTION
Expands the media notes parsing logic to handle additional actions and improve the handling of multi-line entries.

Updated the media_extractor to track and propagate the last action from previous lines.
Extended the supported verbs with new mappings and added tests for ignored actions, typo corrections, and continued actions using "&".