### PR TITLE
API Tagger & Hints Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,5 +66,6 @@ tilt_modules/
 .aider*
 repomix-output.xml
 
-# Raw data files
+# Raw & processed data files
+preprocessing/processed_data/
 preprocessing/raw_data/

--- a/preprocessing/hints.yaml
+++ b/preprocessing/hints.yaml
@@ -1,0 +1,58 @@
+# Media hints file for manual overrides
+# Format:
+# key_phrase:
+#   canonical_title: "Official Title"
+#   type: "Movie|TV|Game|Book"
+#   tags:
+#     genre: ["Genre1", "Genre2"]
+#     platform: ["Platform1", "Platform2"]
+#     mood: ["Mood1", "Mood2"]
+
+# Video Games
+FF7:
+  canonical_title: "Final Fantasy VII Remake"
+  type: "Game"
+  tags:
+    platform: ["PS5"]
+    genre: ["JRPG", "Adventure"]
+    mood: ["Epic"]
+
+Elden:
+  canonical_title: "Elden Ring"
+  type: "Game"
+  tags:
+    platform: ["PS5", "PC"]
+    genre: ["Action RPG", "Open World"]
+    mood: ["Dark Fantasy"]
+
+# Books
+LOTR:
+  canonical_title: "The Lord of the Rings"
+  type: "Book"
+  tags:
+    genre: ["Fantasy"]
+    mood: ["Epic"]
+
+Hobbit:
+  canonical_title: "The Hobbit"
+  type: "Book"
+  tags:
+    genre: ["Fantasy"]
+    mood: ["Adventure"]
+
+# TV Shows
+Succession:
+  canonical_title: "Succession"
+  type: "TV"
+  tags:
+    genre: ["Drama"]
+    platform: ["HBO"]
+    mood: ["Dark"]
+
+# Movies
+Matrix:
+  canonical_title: "The Matrix"
+  type: "Movie"
+  tags:
+    genre: ["Sci-Fi", "Action"]
+    mood: ["Philosophical"]

--- a/preprocessing/media_tagger.py
+++ b/preprocessing/media_tagger.py
@@ -188,7 +188,7 @@ def _combine_votes(
         if "type" not in tagged_entry:
             tagged_entry["type"] = "Other / Unknown"
 
-        if "type" not in tagged_entry:
+        if "tags" not in tagged_entry:
             tagged_entry["tags"] = {}
 
         tagged_entry["confidence"] = 0.1

--- a/preprocessing/media_tagger.py
+++ b/preprocessing/media_tagger.py
@@ -178,6 +178,7 @@ def _combine_votes(
     # Apply the hint if available
     if hint:
         tagged_entry.update(hint)
+        api_hits = [hit for hit in api_hits if hit["type"] == hint["type"]]
 
     # If no API hits were found, fallback as best possible
     if not api_hits:
@@ -195,6 +196,7 @@ def _combine_votes(
         tagged_entry["source"] = "fallback"
         return tagged_entry
 
+    # Sort API hits by confidence so we can check how close the to matches are
     best_api_hit = api_hits[0]
     if len(api_hits) > 1:
         confidence_list = sorted([hit["confidence"] for hit in api_hits], reverse=True)
@@ -246,14 +248,9 @@ def apply_tagging(
         # Apply hints if available
         hint = None
         for hint_key, hint_data in hints.items():
-            if hint_key.lower() in title.lower():
+            if hint_key == title:
                 logger.info("Applying hint for '%s' to entry '%s'", hint_key, entry)
-                title = hint_data.get("canonical_title", title)
-                hint = {
-                    "canonical_title": title,
-                    "type": hint_data["type"],
-                    "tags": hint_data.get("tags", {}),
-                }
+                hint = hint_data
                 break
 
         api_hits = []

--- a/preprocessing/media_tagger.py
+++ b/preprocessing/media_tagger.py
@@ -46,7 +46,7 @@ def _load_hints(hints_path: Optional[str] = DEFAULT_HINTS_PATH) -> Dict:
         return {}
 
 
-def _query_tmdb(title: str) -> Tuple[Optional[str], Optional[Dict], float]:
+def _query_tmdb(title: str) -> List[Dict]:
     """
     Query The Movie Database (TMDB) API for movie and TV show metadata.
 
@@ -83,7 +83,7 @@ def _query_tmdb(title: str) -> Tuple[Optional[str], Optional[Dict], float]:
     ]
 
 
-def _query_igdb(title: str) -> Tuple[Optional[str], Optional[Dict], float]:
+def _query_igdb(title: str) -> List[Dict]:
     """
     Query the Internet Game Database (IGDB) API for video game metadata.
 
@@ -120,7 +120,7 @@ def _query_igdb(title: str) -> Tuple[Optional[str], Optional[Dict], float]:
     ]
 
 
-def _query_openlibrary(title: str) -> Tuple[Optional[str], Optional[Dict], float]:
+def _query_openlibrary(title: str) -> List[Dict]:
     """
     Query the Open Library API for book metadata.
 

--- a/preprocessing/media_tagger.py
+++ b/preprocessing/media_tagger.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_HINTS_PATH = os.path.join(os.path.dirname(__file__), "hints.yaml")
 
 
-def _load_hints(hints_path: str = DEFAULT_HINTS_PATH) -> Dict:
+def _load_hints(hints_path: Optional[str] = DEFAULT_HINTS_PATH) -> Dict:
     """
     Load hints from a YAML file for manual overrides.
 
@@ -25,6 +25,8 @@ def _load_hints(hints_path: str = DEFAULT_HINTS_PATH) -> Dict:
     Returns:
         Dictionary containing hints for media entries.
     """
+    if hints_path is None:
+        hints_path = DEFAULT_HINTS_PATH
     if not os.path.exists(hints_path):
         logger.warning(
             "Hints file not found at %s. No manual overrides will be applied.",
@@ -223,15 +225,13 @@ def _combine_votes(
     return tagged_entry
 
 
-def apply_tagging(
-    entries: List[Dict], hints_path: str = DEFAULT_HINTS_PATH
-) -> List[Dict]:
+def apply_tagging(entries: List[Dict], hints_path: Optional[str] = None) -> List[Dict]:
     """
     Apply tagging to media entries using hints and API calls.
 
     Args:
         entries: List of dictionaries representing media entries.
-        hints_path: Path to the hints YAML file.
+        hints_path: Path to the hints YAML file. Optional.
 
     Returns:
         List of dictionaries with added metadata: canonical_title, type, tags, confidence.

--- a/preprocessing/media_tagger.py
+++ b/preprocessing/media_tagger.py
@@ -1,0 +1,235 @@
+"""
+Preprocessing stage to tag media entries with metadata from external APIs.
+This module includes functions to load hints from YAML and query external APIs.
+"""
+
+import os
+import logging
+import yaml
+from typing import Dict, List, Tuple, Optional, Any
+
+logger = logging.getLogger(__name__)
+
+# Default paths
+DEFAULT_HINTS_PATH = os.path.join(os.path.dirname(__file__), "hints.yaml")
+
+
+def load_hints(hints_path: str = DEFAULT_HINTS_PATH) -> Dict:
+    """
+    Load hints from a YAML file for manual overrides.
+
+    Args:
+        hints_path: Path to the hints YAML file.
+
+    Returns:
+        Dictionary containing hints for media entries.
+    """
+    if not os.path.exists(hints_path):
+        logger.warning("Hints file not found at %s. No manual overrides will be applied.", hints_path)
+        return {}
+
+    try:
+        with open(hints_path, "r", encoding="utf-8") as file:
+            hints = yaml.safe_load(file)
+            if not hints:
+                return {}
+            logger.info("Loaded %d hints from %s", len(hints), hints_path)
+            return hints
+    except (yaml.YAMLError, IOError) as e:
+        logger.error("Error loading hints file: %s", e)
+        return {}
+
+
+def query_tmdb(title: str) -> Tuple[Optional[str], Optional[Dict], float]:
+    """
+    Query The Movie Database (TMDB) API for movie and TV show metadata.
+
+    Args:
+        title: The title of the media to query.
+
+    Returns:
+        Tuple of (canonical_title, metadata, confidence) where:
+            - canonical_title is the official title from TMDB
+            - metadata is a dictionary containing type, genre, etc.
+            - confidence is a float between 0 and 1 indicating match confidence
+    """
+    # This is a stub implementation
+    # In a real implementation, this would make API calls to TMDB
+    logger.info("Querying TMDB for title: %s", title)
+    
+    # Simulate API call
+    api_key = os.environ.get("TMDB_API_KEY")
+    if not api_key:
+        logger.warning("TMDB_API_KEY not found in environment variables")
+        return None, None, 0.0
+    
+    # Mock response - would be replaced with actual API call
+    return title, {"type": "Movie", "tags": {"genre": ["Drama"]}}, 0.8
+
+
+def query_igdb(title: str) -> Tuple[Optional[str], Optional[Dict], float]:
+    """
+    Query the Internet Game Database (IGDB) API for video game metadata.
+
+    Args:
+        title: The title of the game to query.
+
+    Returns:
+        Tuple of (canonical_title, metadata, confidence) where:
+            - canonical_title is the official title from IGDB
+            - metadata is a dictionary containing platform, genre, etc.
+            - confidence is a float between 0 and 1 indicating match confidence
+    """
+    # This is a stub implementation
+    # In a real implementation, this would make API calls to IGDB
+    logger.info("Querying IGDB for title: %s", title)
+    
+    # Simulate API call
+    api_key = os.environ.get("IGDB_API_KEY")
+    if not api_key:
+        logger.warning("IGDB_API_KEY not found in environment variables")
+        return None, None, 0.0
+    
+    # Mock response - would be replaced with actual API call
+    return title, {"type": "Game", "tags": {"platform": ["PC"], "genre": ["RPG"]}}, 0.7
+
+
+def query_openlibrary(title: str) -> Tuple[Optional[str], Optional[Dict], float]:
+    """
+    Query the Open Library API for book metadata.
+
+    Args:
+        title: The title of the book to query.
+
+    Returns:
+        Tuple of (canonical_title, metadata, confidence) where:
+            - canonical_title is the official title from Open Library
+            - metadata is a dictionary containing author, genre, etc.
+            - confidence is a float between 0 and 1 indicating match confidence
+    """
+    # This is a stub implementation
+    # In a real implementation, this would make API calls to Open Library
+    logger.info("Querying Open Library for title: %s", title)
+    
+    # Simulate API call
+    api_key = os.environ.get("OPENLIBRARY_API_KEY")
+    if not api_key:
+        logger.warning("OPENLIBRARY_API_KEY not found in environment variables")
+        return None, None, 0.0
+    
+    # Mock response - would be replaced with actual API call
+    return title, {"type": "Book", "tags": {"genre": ["Fiction"]}}, 0.6
+
+
+def guess_media_type(title: str) -> str:
+    """
+    Make a best guess at the media type based on the title.
+    This is a fallback when API calls fail or aren't available.
+
+    Args:
+        title: The title of the media.
+
+    Returns:
+        A string representing the guessed media type: "Movie", "TV", "Game", or "Book".
+    """
+    # This is a very simple heuristic and would be improved in a real implementation
+    lower_title = title.lower()
+    
+    # Check for common video game indicators
+    if any(term in lower_title for term in ["game", "played", "gaming"]):
+        return "Game"
+    
+    # Check for common TV show indicators
+    if any(term in lower_title for term in ["season", "episode", "tv", "show", "series"]):
+        return "TV"
+    
+    # Check for common book indicators
+    if any(term in lower_title for term in ["book", "novel", "read"]):
+        return "Book"
+    
+    # Default to Movie if no other indicators
+    return "Movie"
+
+
+def apply_tagging(entries: List[Dict], hints_path: str = DEFAULT_HINTS_PATH) -> List[Dict]:
+    """
+    Apply tagging to media entries using hints and API calls.
+
+    Args:
+        entries: List of dictionaries representing media entries.
+        hints_path: Path to the hints YAML file.
+
+    Returns:
+        List of dictionaries with added metadata: canonical_title, type, tags, confidence.
+    """
+    hints = load_hints(hints_path)
+    tagged_entries = []
+    
+    for entry in entries:
+        title = entry.get("title", "")
+        if not title:
+            logger.warning("Entry missing title, skipping tagging: %s", entry)
+            tagged_entries.append(entry)
+            continue
+        
+        # Start with a copy of the original entry
+        tagged_entry = entry.copy()
+        
+        # Apply hints if available
+        hint_applied = False
+        for hint_key, hint_data in hints.items():
+            if hint_key.lower() in title.lower():
+                logger.info("Applying hint for '%s' to entry '%s'", hint_key, title)
+                tagged_entry["canonical_title"] = hint_data.get("canonical_title", title)
+                tagged_entry["type"] = hint_data.get("type")
+                tagged_entry["tags"] = hint_data.get("tags", {})
+                tagged_entry["confidence"] = 1.0  # Hints have perfect confidence
+                hint_applied = True
+                break
+        
+        if hint_applied:
+            tagged_entries.append(tagged_entry)
+            continue
+        
+        # If no hint, try API calls based on guessed media type
+        media_type = guess_media_type(title)
+        canonical_title = None
+        metadata = None
+        confidence = 0.0
+        
+        if media_type == "Movie" or media_type == "TV":
+            canonical_title, metadata, confidence = query_tmdb(title)
+        elif media_type == "Game":
+            canonical_title, metadata, confidence = query_igdb(title)
+        elif media_type == "Book":
+            canonical_title, metadata, confidence = query_openlibrary(title)
+        
+        if canonical_title and metadata:
+            tagged_entry["canonical_title"] = canonical_title
+            tagged_entry["type"] = metadata.get("type", media_type)
+            tagged_entry["tags"] = metadata.get("tags", {})
+            tagged_entry["confidence"] = confidence
+        else:
+            # Fallback if API calls fail
+            tagged_entry["canonical_title"] = title
+            tagged_entry["type"] = media_type
+            tagged_entry["tags"] = {}
+            tagged_entry["confidence"] = 0.1  # Low confidence for guesses
+            tagged_entry["warnings"] = tagged_entry.get("warnings", []) + ["Failed to fetch metadata from APIs"]
+        
+        tagged_entries.append(tagged_entry)
+    
+    logger.info("Tagged %d entries with metadata", len(tagged_entries))
+    return tagged_entries
+
+
+if __name__ == "__main__":
+    # Example usage
+    sample_entries = [
+        {"title": "The Hobbit", "action": "started", "date": "2023-01-01"},
+        {"title": "Elden Ring", "action": "finished", "date": "2023-02-15"},
+    ]
+    
+    tagged = apply_tagging(sample_entries)
+    for entry in tagged:
+        print(f"Tagged entry: {entry}")

--- a/preprocessing/media_tagger.py
+++ b/preprocessing/media_tagger.py
@@ -56,13 +56,13 @@ def query_tmdb(title: str) -> Tuple[Optional[str], Optional[Dict], float]:
     # This is a stub implementation
     # In a real implementation, this would make API calls to TMDB
     logger.info("Querying TMDB for title: %s", title)
-    
+
     # Simulate API call
     api_key = os.environ.get("TMDB_API_KEY")
     if not api_key:
         logger.warning("TMDB_API_KEY not found in environment variables")
         return None, None, 0.0
-    
+
     # Mock response - would be replaced with actual API call
     return title, {"type": "Movie", "tags": {"genre": ["Drama"]}}, 0.8
 
@@ -83,13 +83,13 @@ def query_igdb(title: str) -> Tuple[Optional[str], Optional[Dict], float]:
     # This is a stub implementation
     # In a real implementation, this would make API calls to IGDB
     logger.info("Querying IGDB for title: %s", title)
-    
+
     # Simulate API call
     api_key = os.environ.get("IGDB_API_KEY")
     if not api_key:
         logger.warning("IGDB_API_KEY not found in environment variables")
         return None, None, 0.0
-    
+
     # Mock response - would be replaced with actual API call
     return title, {"type": "Game", "tags": {"platform": ["PC"], "genre": ["RPG"]}}, 0.7
 
@@ -110,13 +110,13 @@ def query_openlibrary(title: str) -> Tuple[Optional[str], Optional[Dict], float]
     # This is a stub implementation
     # In a real implementation, this would make API calls to Open Library
     logger.info("Querying Open Library for title: %s", title)
-    
+
     # Simulate API call
     api_key = os.environ.get("OPENLIBRARY_API_KEY")
     if not api_key:
         logger.warning("OPENLIBRARY_API_KEY not found in environment variables")
         return None, None, 0.0
-    
+
     # Mock response - would be replaced with actual API call
     return title, {"type": "Book", "tags": {"genre": ["Fiction"]}}, 0.6
 
@@ -134,19 +134,19 @@ def guess_media_type(title: str) -> str:
     """
     # This is a very simple heuristic and would be improved in a real implementation
     lower_title = title.lower()
-    
+
     # Check for common video game indicators
     if any(term in lower_title for term in ["game", "played", "gaming"]):
         return "Game"
-    
+
     # Check for common TV show indicators
     if any(term in lower_title for term in ["season", "episode", "tv", "show", "series"]):
         return "TV"
-    
+
     # Check for common book indicators
     if any(term in lower_title for term in ["book", "novel", "read"]):
         return "Book"
-    
+
     # Default to Movie if no other indicators
     return "Movie"
 
@@ -164,17 +164,17 @@ def apply_tagging(entries: List[Dict], hints_path: str = DEFAULT_HINTS_PATH) -> 
     """
     hints = load_hints(hints_path)
     tagged_entries = []
-    
+
     for entry in entries:
         title = entry.get("title", "")
         if not title:
             logger.warning("Entry missing title, skipping tagging: %s", entry)
             tagged_entries.append(entry)
             continue
-        
+
         # Start with a copy of the original entry
         tagged_entry = entry.copy()
-        
+
         # Apply hints if available
         hint_applied = False
         for hint_key, hint_data in hints.items():
@@ -186,24 +186,24 @@ def apply_tagging(entries: List[Dict], hints_path: str = DEFAULT_HINTS_PATH) -> 
                 tagged_entry["confidence"] = 1.0  # Hints have perfect confidence
                 hint_applied = True
                 break
-        
+
         if hint_applied:
             tagged_entries.append(tagged_entry)
             continue
-        
+
         # If no hint, try API calls based on guessed media type
         media_type = guess_media_type(title)
         canonical_title = None
         metadata = None
         confidence = 0.0
-        
+
         if media_type == "Movie" or media_type == "TV":
             canonical_title, metadata, confidence = query_tmdb(title)
         elif media_type == "Game":
             canonical_title, metadata, confidence = query_igdb(title)
         elif media_type == "Book":
             canonical_title, metadata, confidence = query_openlibrary(title)
-        
+
         if canonical_title and metadata:
             tagged_entry["canonical_title"] = canonical_title
             tagged_entry["type"] = metadata.get("type", media_type)
@@ -216,9 +216,9 @@ def apply_tagging(entries: List[Dict], hints_path: str = DEFAULT_HINTS_PATH) -> 
             tagged_entry["tags"] = {}
             tagged_entry["confidence"] = 0.1  # Low confidence for guesses
             tagged_entry["warnings"] = tagged_entry.get("warnings", []) + ["Failed to fetch metadata from APIs"]
-        
+
         tagged_entries.append(tagged_entry)
-    
+
     logger.info("Tagged %d entries with metadata", len(tagged_entries))
     return tagged_entries
 
@@ -229,7 +229,7 @@ if __name__ == "__main__":
         {"title": "The Hobbit", "action": "started", "date": "2023-01-01"},
         {"title": "Elden Ring", "action": "finished", "date": "2023-02-15"},
     ]
-    
+
     tagged = apply_tagging(sample_entries)
     for entry in tagged:
         print(f"Tagged entry: {entry}")

--- a/preprocessing/media_tagger.py
+++ b/preprocessing/media_tagger.py
@@ -5,8 +5,8 @@ This module includes functions to load hints from YAML and query external APIs.
 
 import os
 import logging
+from typing import Dict, List, Tuple, Optional
 import yaml
-from typing import Dict, List, Tuple, Optional, Any
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +25,10 @@ def load_hints(hints_path: str = DEFAULT_HINTS_PATH) -> Dict:
         Dictionary containing hints for media entries.
     """
     if not os.path.exists(hints_path):
-        logger.warning("Hints file not found at %s. No manual overrides will be applied.", hints_path)
+        logger.warning(
+            "Hints file not found at %s. No manual overrides will be applied.",
+            hints_path,
+        )
         return {}
 
     try:
@@ -140,7 +143,9 @@ def guess_media_type(title: str) -> str:
         return "Game"
 
     # Check for common TV show indicators
-    if any(term in lower_title for term in ["season", "episode", "tv", "show", "series"]):
+    if any(
+        term in lower_title for term in ["season", "episode", "tv", "show", "series"]
+    ):
         return "TV"
 
     # Check for common book indicators
@@ -151,7 +156,9 @@ def guess_media_type(title: str) -> str:
     return "Movie"
 
 
-def apply_tagging(entries: List[Dict], hints_path: str = DEFAULT_HINTS_PATH) -> List[Dict]:
+def apply_tagging(
+    entries: List[Dict], hints_path: str = DEFAULT_HINTS_PATH
+) -> List[Dict]:
     """
     Apply tagging to media entries using hints and API calls.
 
@@ -180,7 +187,9 @@ def apply_tagging(entries: List[Dict], hints_path: str = DEFAULT_HINTS_PATH) -> 
         for hint_key, hint_data in hints.items():
             if hint_key.lower() in title.lower():
                 logger.info("Applying hint for '%s' to entry '%s'", hint_key, title)
-                tagged_entry["canonical_title"] = hint_data.get("canonical_title", title)
+                tagged_entry["canonical_title"] = hint_data.get(
+                    "canonical_title", title
+                )
                 tagged_entry["type"] = hint_data.get("type")
                 tagged_entry["tags"] = hint_data.get("tags", {})
                 tagged_entry["confidence"] = 1.0  # Hints have perfect confidence
@@ -197,7 +206,7 @@ def apply_tagging(entries: List[Dict], hints_path: str = DEFAULT_HINTS_PATH) -> 
         metadata = None
         confidence = 0.0
 
-        if media_type == "Movie" or media_type == "TV":
+        if media_type in ("Movie", "TV"):
             canonical_title, metadata, confidence = query_tmdb(title)
         elif media_type == "Game":
             canonical_title, metadata, confidence = query_igdb(title)
@@ -215,7 +224,9 @@ def apply_tagging(entries: List[Dict], hints_path: str = DEFAULT_HINTS_PATH) -> 
             tagged_entry["type"] = media_type
             tagged_entry["tags"] = {}
             tagged_entry["confidence"] = 0.1  # Low confidence for guesses
-            tagged_entry["warnings"] = tagged_entry.get("warnings", []) + ["Failed to fetch metadata from APIs"]
+            tagged_entry["warnings"] = tagged_entry.get("warnings", []) + [
+                "Failed to fetch metadata from APIs"
+            ]
 
         tagged_entries.append(tagged_entry)
 
@@ -231,5 +242,5 @@ if __name__ == "__main__":
     ]
 
     tagged = apply_tagging(sample_entries)
-    for entry in tagged:
-        print(f"Tagged entry: {entry}")
+    for curr_entry in tagged:
+        print(f"Tagged entry: {curr_entry}")

--- a/preprocessing/preprocess.py
+++ b/preprocessing/preprocess.py
@@ -4,11 +4,13 @@ This module includes functions to parse date ranges and load records from a CSV 
 """
 
 import csv
+import json
 import logging
 from typing import List, Dict
 
 from .media_extractor import extract_entries
 from .week_extractor import parse_row
+from .media_tagger import apply_tagging
 
 
 logger = logging.getLogger(__name__)
@@ -49,20 +51,116 @@ def load_weekly_records(path: str) -> List[Dict]:
     return records
 
 
+def process_and_save(input_csv: str, output_json: str, hints_path: str = None) -> Dict:
+    """
+    Process the input CSV file and save the results to a JSON file.
+
+    Args:
+        input_csv: Path to the input CSV file.
+        output_json: Path to the output JSON file.
+        hints_path: Path to the hints YAML file. Optional.
+
+    Returns:
+        Dictionary with statistics about the processing.
+    """
+    # Load weekly records
+    weekly_records = load_weekly_records(input_csv)
+    logger.info("Loaded %d weekly records from %s", len(weekly_records), input_csv)
+
+    # Extract media entries
+    all_entries = []
+    for curr_record in weekly_records:
+        all_entries.extend(extract_entries(curr_record))
+    logger.info("Extracted %d media entries", len(all_entries))
+
+    # Apply tagging
+    tagged_entries = apply_tagging(all_entries, hints_path)
+    logger.info("Tagged %d media entries", len(tagged_entries))
+
+    # Calculate statistics
+    stats = calculate_statistics(tagged_entries)
+
+    # Save to JSON
+    try:
+        with open(output_json, "w", encoding="utf-8") as f:
+            json.dump(tagged_entries, f, indent=2)
+        logger.info("Saved %d entries to %s", len(tagged_entries), output_json)
+    except IOError as e:
+        logger.error("Error saving to JSON file: %s", e)
+        raise
+
+    return stats
+
+
+def calculate_statistics(entries: List[Dict]) -> Dict:
+    """
+    Calculate statistics about the processed entries.
+
+    Args:
+        entries: List of processed media entries.
+
+    Returns:
+        Dictionary with statistics.
+    """
+    stats = {
+        "total_entries": len(entries),
+        "by_type": {},
+        "start_only": 0,
+        "finish_only": 0,
+        "completed": 0,
+        "low_confidence": 0,
+        "with_warnings": 0,
+        "hint_applied": 0,
+    }
+
+    for entry in entries:
+        # Count by media type
+        media_type = entry.get("type", "Unknown")
+        stats["by_type"][media_type] = stats["by_type"].get(media_type, 0) + 1
+
+        # Count entries by status
+        if entry.get("action") == "started" and "finish_date" not in entry:
+            stats["start_only"] += 1
+        elif entry.get("action") == "finished" and "start_date" not in entry:
+            stats["finish_only"] += 1
+        elif "start_date" in entry and "finish_date" in entry:
+            stats["completed"] += 1
+
+        # Count low confidence entries
+        if entry.get("confidence", 0) < 0.5:
+            stats["low_confidence"] += 1
+
+        # Count entries with warnings
+        if entry.get("warnings", []):
+            stats["with_warnings"] += 1
+
+        # Count entries with hints applied
+        if entry.get("confidence", 0) == 1.0:
+            stats["hint_applied"] += 1
+
+    return stats
+
+
 if __name__ == "__main__":
     # Configure logging
     logging.basicConfig(
-        level=logging.WARN,
+        level=logging.INFO,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         filename="preprocess.log",
         filemode="w",
     )
 
-    # Example usage
-    weekly_records = load_weekly_records("preprocessing/raw_data/media_enjoyed.csv")
-    print(f"Loaded {len(weekly_records)} records")
-
-    all_entries = []
-    for curr_record in weekly_records:
-        all_entries.extend(extract_entries(curr_record))
-    print(f"Extracted {len(all_entries)} entries")
+    # Process and save
+    input_file = "preprocessing/raw_data/media_enjoyed.csv"
+    output_file = "preprocessing/media_entries.json"
+    stats = process_and_save(input_file, output_file)
+    
+    # Print statistics
+    print(f"Processed {stats['total_entries']} media entries:")
+    print(f"  By type: {stats['by_type']}")
+    print(f"  Start only: {stats['start_only']}")
+    print(f"  Finish only: {stats['finish_only']}")
+    print(f"  Completed: {stats['completed']}")
+    print(f"  Low confidence: {stats['low_confidence']}")
+    print(f"  With warnings: {stats['with_warnings']}")
+    print(f"  Hint applied: {stats['hint_applied']}")

--- a/preprocessing/preprocess.py
+++ b/preprocessing/preprocess.py
@@ -151,16 +151,16 @@ if __name__ == "__main__":
     )
 
     # Process and save
-    input_file = "preprocessing/raw_data/media_enjoyed.csv"
-    output_file = "preprocessing/media_entries.json"
-    stats = process_and_save(input_file, output_file)
+    final_stats = process_and_save(
+        "preprocessing/raw_data/media_enjoyed.csv", "preprocessing/media_entries.json"
+    )
 
     # Print statistics
-    print(f"Processed {stats['total_entries']} media entries:")
-    print(f"  By type: {stats['by_type']}")
-    print(f"  Start only: {stats['start_only']}")
-    print(f"  Finish only: {stats['finish_only']}")
-    print(f"  Completed: {stats['completed']}")
-    print(f"  Low confidence: {stats['low_confidence']}")
-    print(f"  With warnings: {stats['with_warnings']}")
-    print(f"  Hint applied: {stats['hint_applied']}")
+    print(f"Processed {final_stats['total_entries']} media entries:")
+    print(f"  By type: {final_stats['by_type']}")
+    print(f"  Start only: {final_stats['start_only']}")
+    print(f"  Finish only: {final_stats['finish_only']}")
+    print(f"  Completed: {final_stats['completed']}")
+    print(f"  Low confidence: {final_stats['low_confidence']}")
+    print(f"  With warnings: {final_stats['with_warnings']}")
+    print(f"  Hint applied: {final_stats['hint_applied']}")

--- a/preprocessing/preprocess.py
+++ b/preprocessing/preprocess.py
@@ -105,12 +105,7 @@ def calculate_statistics(entries: List[Dict]) -> Dict:
     stats = {
         "total_entries": len(entries),
         "by_type": {},
-        "start_only": 0,
-        "finish_only": 0,
-        "completed": 0,
         "low_confidence": 0,
-        "with_warnings": 0,
-        "hint_applied": 0,
     }
 
     for entry in entries:
@@ -118,25 +113,9 @@ def calculate_statistics(entries: List[Dict]) -> Dict:
         media_type = entry.get("type", "Unknown")
         stats["by_type"][media_type] = stats["by_type"].get(media_type, 0) + 1
 
-        # Count entries by status
-        if entry.get("action") == "started" and "finish_date" not in entry:
-            stats["start_only"] += 1
-        elif entry.get("action") == "finished" and "start_date" not in entry:
-            stats["finish_only"] += 1
-        elif "start_date" in entry and "finish_date" in entry:
-            stats["completed"] += 1
-
         # Count low confidence entries
         if entry.get("confidence", 0) < 0.5:
             stats["low_confidence"] += 1
-
-        # Count entries with warnings
-        if entry.get("warnings", []):
-            stats["with_warnings"] += 1
-
-        # Count entries with hints applied
-        if entry.get("confidence", 0) == 1.0:
-            stats["hint_applied"] += 1
 
     return stats
 
@@ -152,15 +131,11 @@ if __name__ == "__main__":
 
     # Process and save
     final_stats = process_and_save(
-        "preprocessing/raw_data/media_enjoyed.csv", "preprocessing/media_entries.json"
+        "preprocessing/raw_data/media_enjoyed.csv",
+        "preprocessing/processed_data/media_entries.json",
     )
 
     # Print statistics
     print(f"Processed {final_stats['total_entries']} media entries:")
     print(f"  By type: {final_stats['by_type']}")
-    print(f"  Start only: {final_stats['start_only']}")
-    print(f"  Finish only: {final_stats['finish_only']}")
-    print(f"  Completed: {final_stats['completed']}")
     print(f"  Low confidence: {final_stats['low_confidence']}")
-    print(f"  With warnings: {final_stats['with_warnings']}")
-    print(f"  Hint applied: {final_stats['hint_applied']}")

--- a/preprocessing/preprocess.py
+++ b/preprocessing/preprocess.py
@@ -144,7 +144,7 @@ def calculate_statistics(entries: List[Dict]) -> Dict:
 if __name__ == "__main__":
     # Configure logging
     logging.basicConfig(
-        level=logging.INFO,
+        level=logging.WARN,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         filename="preprocess.log",
         filemode="w",
@@ -154,7 +154,7 @@ if __name__ == "__main__":
     input_file = "preprocessing/raw_data/media_enjoyed.csv"
     output_file = "preprocessing/media_entries.json"
     stats = process_and_save(input_file, output_file)
-    
+
     # Print statistics
     print(f"Processed {stats['total_entries']} media entries:")
     print(f"  By type: {stats['by_type']}")

--- a/prompt_plan.md
+++ b/prompt_plan.md
@@ -97,7 +97,7 @@ Write pytest tests in `tests/test_extractor.py` for:
 
 ### Prompt 4: API Tagger & Hints Support  
 ```text
-Create `tagger.py`:
+Create `preprocessing/media_tagger.py`:
 - Load `hints.yaml` for manual overrides.
 - Implement stub functions:
   - `query_tmdb(title: str) -> (canonical_title, metadata, confidence)`
@@ -106,7 +106,7 @@ Create `tagger.py`:
   - Apply hints first, then API calls.
   - Attach `type`, `tags` (genre, platform, mood), and `confidence`.
 
-Write tests in `tests/test_tagger.py` using mocked API responses and hint scenarios.
+Write tests in `tests/test_media_tagger.py` using mocked API responses and hint scenarios.
 ```
 
 ### Prompt 5: JSON Schema & Validation  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+PyYAML==6.0.2
 pydantic==2.11.4
 requests==2.32.3
 spacy==3.8.4

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -1,0 +1,220 @@
+"""Unit tests for the media tagging functionality."""
+
+import os
+import yaml
+from unittest.mock import patch, mock_open, MagicMock
+
+import pytest
+
+from preprocessing.media_tagger import (
+    load_hints,
+    query_tmdb,
+    query_igdb,
+    query_openlibrary,
+    guess_media_type,
+    apply_tagging,
+)
+
+
+@pytest.fixture
+def sample_hints():
+    """Sample hints data for testing."""
+    return {
+        "FF7": {
+            "canonical_title": "Final Fantasy VII Remake",
+            "type": "Game",
+            "tags": {
+                "platform": ["PS5"],
+                "genre": ["JRPG", "Adventure"],
+                "mood": ["Epic"],
+            },
+        },
+        "LOTR": {
+            "canonical_title": "The Lord of the Rings",
+            "type": "Book",
+            "tags": {
+                "genre": ["Fantasy"],
+                "mood": ["Epic"],
+            },
+        },
+    }
+
+
+@pytest.fixture
+def sample_entries():
+    """Sample media entries for testing."""
+    return [
+        {"title": "Started FF7", "action": "started", "date": "2023-01-01"},
+        {"title": "Finished The Hobbit", "action": "finished", "date": "2023-02-15"},
+        {"title": "Watched Succession", "action": "watched", "date": "2023-03-10"},
+    ]
+
+
+def test_load_hints_success(sample_hints):
+    """Test loading hints from a YAML file successfully."""
+    mock_yaml_content = yaml.dump(sample_hints)
+    
+    with patch("builtins.open", mock_open(read_data=mock_yaml_content)):
+        with patch("os.path.exists", return_value=True):
+            hints = load_hints("fake_path.yaml")
+    
+    assert hints == sample_hints
+    assert "FF7" in hints
+    assert hints["FF7"]["canonical_title"] == "Final Fantasy VII Remake"
+
+
+def test_load_hints_file_not_found():
+    """Test handling when hints file is not found."""
+    with patch("os.path.exists", return_value=False):
+        hints = load_hints("nonexistent_file.yaml")
+    
+    assert hints == {}
+
+
+def test_load_hints_invalid_yaml():
+    """Test handling invalid YAML content."""
+    invalid_yaml = "invalid: yaml: content: - ["
+    
+    with patch("builtins.open", mock_open(read_data=invalid_yaml)):
+        with patch("os.path.exists", return_value=True):
+            hints = load_hints("invalid.yaml")
+    
+    assert hints == {}
+
+
+def test_query_tmdb():
+    """Test querying TMDB API."""
+    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}):
+        title, metadata, confidence = query_tmdb("The Matrix")
+    
+    # Since this is a stub, we're just checking the structure
+    assert title is not None
+    assert isinstance(metadata, dict)
+    assert "type" in metadata
+    assert 0 <= confidence <= 1
+
+
+def test_query_tmdb_no_api_key():
+    """Test querying TMDB API with no API key."""
+    with patch.dict(os.environ, {}, clear=True):
+        title, metadata, confidence = query_tmdb("The Matrix")
+    
+    assert title is None
+    assert metadata is None
+    assert confidence == 0.0
+
+
+def test_query_igdb():
+    """Test querying IGDB API."""
+    with patch.dict(os.environ, {"IGDB_API_KEY": "fake_key"}):
+        title, metadata, confidence = query_igdb("Elden Ring")
+    
+    # Since this is a stub, we're just checking the structure
+    assert title is not None
+    assert isinstance(metadata, dict)
+    assert "type" in metadata
+    assert 0 <= confidence <= 1
+
+
+def test_query_openlibrary():
+    """Test querying Open Library API."""
+    with patch.dict(os.environ, {"OPENLIBRARY_API_KEY": "fake_key"}):
+        title, metadata, confidence = query_openlibrary("The Hobbit")
+    
+    # Since this is a stub, we're just checking the structure
+    assert title is not None
+    assert isinstance(metadata, dict)
+    assert "type" in metadata
+    assert 0 <= confidence <= 1
+
+
+def test_guess_media_type():
+    """Test guessing media type from title."""
+    assert guess_media_type("Played Elden Ring") == "Game"
+    assert guess_media_type("Watched Season 2 of Succession") == "TV"
+    assert guess_media_type("Read The Hobbit") == "Book"
+    assert guess_media_type("Avatar") == "Movie"  # Default case
+
+
+def test_apply_tagging_with_hints(sample_entries, sample_hints):
+    """Test applying tagging with hints."""
+    mock_yaml_content = yaml.dump(sample_hints)
+    
+    with patch("builtins.open", mock_open(read_data=mock_yaml_content)):
+        with patch("os.path.exists", return_value=True):
+            tagged_entries = apply_tagging(sample_entries, "fake_path.yaml")
+    
+    # Check the entry that should match a hint
+    ff7_entry = next(entry for entry in tagged_entries if "FF7" in entry["title"])
+    assert ff7_entry["canonical_title"] == "Final Fantasy VII Remake"
+    assert ff7_entry["type"] == "Game"
+    assert ff7_entry["tags"]["platform"] == ["PS5"]
+    assert ff7_entry["confidence"] == 1.0
+
+
+def test_apply_tagging_with_api_calls(sample_entries):
+    """Test applying tagging with API calls when no hints match."""
+    # Mock the API calls
+    with patch("preprocessing.media_tagger.load_hints", return_value={}):
+        with patch("preprocessing.media_tagger.query_tmdb") as mock_tmdb:
+            with patch("preprocessing.media_tagger.query_igdb") as mock_igdb:
+                with patch("preprocessing.media_tagger.query_openlibrary") as mock_openlibrary:
+                    # Set up mock returns
+                    mock_tmdb.return_value = (
+                        "Succession",
+                        {"type": "TV", "tags": {"genre": ["Drama"]}},
+                        0.9,
+                    )
+                    mock_openlibrary.return_value = (
+                        "The Hobbit",
+                        {"type": "Book", "tags": {"genre": ["Fantasy"]}},
+                        0.8,
+                    )
+                    
+                    tagged_entries = apply_tagging(sample_entries)
+    
+    # Check the TV show entry
+    succession_entry = next(entry for entry in tagged_entries if "Succession" in entry["title"])
+    assert succession_entry["canonical_title"] == "Succession"
+    assert succession_entry["type"] == "TV"
+    assert succession_entry["tags"]["genre"] == ["Drama"]
+    assert succession_entry["confidence"] == 0.9
+    
+    # Check the book entry
+    hobbit_entry = next(entry for entry in tagged_entries if "Hobbit" in entry["title"])
+    assert hobbit_entry["canonical_title"] == "The Hobbit"
+    assert hobbit_entry["type"] == "Book"
+    assert hobbit_entry["tags"]["genre"] == ["Fantasy"]
+    assert hobbit_entry["confidence"] == 0.8
+
+
+def test_apply_tagging_api_failure(sample_entries):
+    """Test applying tagging when API calls fail."""
+    # Mock the API calls to fail
+    with patch("preprocessing.media_tagger.load_hints", return_value={}):
+        with patch("preprocessing.media_tagger.query_tmdb", return_value=(None, None, 0.0)):
+            with patch("preprocessing.media_tagger.query_igdb", return_value=(None, None, 0.0)):
+                with patch("preprocessing.media_tagger.query_openlibrary", return_value=(None, None, 0.0)):
+                    tagged_entries = apply_tagging(sample_entries)
+    
+    # Check that fallback values are used
+    for entry in tagged_entries:
+        assert "canonical_title" in entry
+        assert "type" in entry
+        assert "tags" in entry
+        assert entry["tags"] == {}
+        assert entry["confidence"] == 0.1
+        assert "warnings" in entry
+        assert "Failed to fetch metadata from APIs" in entry["warnings"]
+
+
+def test_apply_tagging_missing_title():
+    """Test applying tagging to an entry with a missing title."""
+    entries = [{"action": "started", "date": "2023-01-01"}]  # Missing title
+    
+    with patch("preprocessing.media_tagger.load_hints", return_value={}):
+        tagged_entries = apply_tagging(entries)
+    
+    assert len(tagged_entries) == 1
+    assert "canonical_title" not in tagged_entries[0]
+    assert "type" not in tagged_entries[0]

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -16,8 +16,8 @@ from preprocessing.media_tagger import (
 )
 
 
-@pytest.fixture
-def sample_hints():
+@pytest.fixture(name="sample_hints")
+def fixture_sample_hints():
     """Sample hints data for testing."""
     return {
         "FF7": {
@@ -40,8 +40,8 @@ def sample_hints():
     }
 
 
-@pytest.fixture
-def sample_entries():
+@pytest.fixture(name="sample_entries")
+def fixture_sample_entries():
     """Sample media entries for testing."""
     return [
         {"title": "Started FF7", "action": "started", "date": "2023-01-01"},

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -102,7 +102,7 @@ def test_query_tmdb_no_api_key(caplog):
         api_hits = _query_tmdb("The Matrix")
 
     assert "TMDB_API_KEY not found in environment variables" in caplog.text
-    assert api_hits == []
+    assert not api_hits
 
 
 def test_query_igdb():

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -53,11 +53,11 @@ def sample_entries():
 def test_load_hints_success(sample_hints):
     """Test loading hints from a YAML file successfully."""
     mock_yaml_content = yaml.dump(sample_hints)
-    
+
     with patch("builtins.open", mock_open(read_data=mock_yaml_content)):
         with patch("os.path.exists", return_value=True):
             hints = load_hints("fake_path.yaml")
-    
+
     assert hints == sample_hints
     assert "FF7" in hints
     assert hints["FF7"]["canonical_title"] == "Final Fantasy VII Remake"
@@ -67,18 +67,18 @@ def test_load_hints_file_not_found():
     """Test handling when hints file is not found."""
     with patch("os.path.exists", return_value=False):
         hints = load_hints("nonexistent_file.yaml")
-    
+
     assert hints == {}
 
 
 def test_load_hints_invalid_yaml():
     """Test handling invalid YAML content."""
     invalid_yaml = "invalid: yaml: content: - ["
-    
+
     with patch("builtins.open", mock_open(read_data=invalid_yaml)):
         with patch("os.path.exists", return_value=True):
             hints = load_hints("invalid.yaml")
-    
+
     assert hints == {}
 
 
@@ -86,7 +86,7 @@ def test_query_tmdb():
     """Test querying TMDB API."""
     with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}):
         title, metadata, confidence = query_tmdb("The Matrix")
-    
+
     # Since this is a stub, we're just checking the structure
     assert title is not None
     assert isinstance(metadata, dict)
@@ -98,7 +98,7 @@ def test_query_tmdb_no_api_key():
     """Test querying TMDB API with no API key."""
     with patch.dict(os.environ, {}, clear=True):
         title, metadata, confidence = query_tmdb("The Matrix")
-    
+
     assert title is None
     assert metadata is None
     assert confidence == 0.0
@@ -108,7 +108,7 @@ def test_query_igdb():
     """Test querying IGDB API."""
     with patch.dict(os.environ, {"IGDB_API_KEY": "fake_key"}):
         title, metadata, confidence = query_igdb("Elden Ring")
-    
+
     # Since this is a stub, we're just checking the structure
     assert title is not None
     assert isinstance(metadata, dict)
@@ -120,7 +120,7 @@ def test_query_openlibrary():
     """Test querying Open Library API."""
     with patch.dict(os.environ, {"OPENLIBRARY_API_KEY": "fake_key"}):
         title, metadata, confidence = query_openlibrary("The Hobbit")
-    
+
     # Since this is a stub, we're just checking the structure
     assert title is not None
     assert isinstance(metadata, dict)
@@ -139,11 +139,11 @@ def test_guess_media_type():
 def test_apply_tagging_with_hints(sample_entries, sample_hints):
     """Test applying tagging with hints."""
     mock_yaml_content = yaml.dump(sample_hints)
-    
+
     with patch("builtins.open", mock_open(read_data=mock_yaml_content)):
         with patch("os.path.exists", return_value=True):
             tagged_entries = apply_tagging(sample_entries, "fake_path.yaml")
-    
+
     # Check the entry that should match a hint
     ff7_entry = next(entry for entry in tagged_entries if "FF7" in entry["title"])
     assert ff7_entry["canonical_title"] == "Final Fantasy VII Remake"
@@ -170,16 +170,16 @@ def test_apply_tagging_with_api_calls(sample_entries):
                         {"type": "Book", "tags": {"genre": ["Fantasy"]}},
                         0.8,
                     )
-                    
+
                     tagged_entries = apply_tagging(sample_entries)
-    
+
     # Check the TV show entry
     succession_entry = next(entry for entry in tagged_entries if "Succession" in entry["title"])
     assert succession_entry["canonical_title"] == "Succession"
     assert succession_entry["type"] == "TV"
     assert succession_entry["tags"]["genre"] == ["Drama"]
     assert succession_entry["confidence"] == 0.9
-    
+
     # Check the book entry
     hobbit_entry = next(entry for entry in tagged_entries if "Hobbit" in entry["title"])
     assert hobbit_entry["canonical_title"] == "The Hobbit"
@@ -196,7 +196,7 @@ def test_apply_tagging_api_failure(sample_entries):
             with patch("preprocessing.media_tagger.query_igdb", return_value=(None, None, 0.0)):
                 with patch("preprocessing.media_tagger.query_openlibrary", return_value=(None, None, 0.0)):
                     tagged_entries = apply_tagging(sample_entries)
-    
+
     # Check that fallback values are used
     for entry in tagged_entries:
         assert "canonical_title" in entry
@@ -211,10 +211,10 @@ def test_apply_tagging_api_failure(sample_entries):
 def test_apply_tagging_missing_title():
     """Test applying tagging to an entry with a missing title."""
     entries = [{"action": "started", "date": "2023-01-01"}]  # Missing title
-    
+
     with patch("preprocessing.media_tagger.load_hints", return_value={}):
         tagged_entries = apply_tagging(entries)
-    
+
     assert len(tagged_entries) == 1
     assert "canonical_title" not in tagged_entries[0]
     assert "type" not in tagged_entries[0]

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -51,19 +51,19 @@ def test_process_and_save():
     csv_content = "\n".join(
         [line.strip() for line in csv_content.getvalue().splitlines()]
     )
-    
+
     # Mock dependencies
     with patch("builtins.open", mock_open()) as mock_file:
         # Configure the mock to return our CSV content when opened for reading
         mock_file.return_value.__enter__.return_value.read.return_value = csv_content
-        
+
         # Mock the extract_entries function
         with patch("preprocessing.preprocess.extract_entries") as mock_extract:
             mock_extract.return_value = [
                 {"title": "The Hobbit", "action": "started", "date": "2023-01-01"},
                 {"title": "The Hobbit", "action": "finished", "date": "2023-02-01"},
             ]
-            
+
             # Mock the apply_tagging function
             with patch("preprocessing.preprocess.apply_tagging") as mock_tag:
                 mock_tag.return_value = [
@@ -86,10 +86,10 @@ def test_process_and_save():
                         "confidence": 0.9,
                     },
                 ]
-                
+
                 # Call the function under test
                 stats = process_and_save("input.csv", "output.json")
-    
+
     # Verify the results
     assert stats["total_entries"] == 2
     assert stats["by_type"]["Book"] == 2
@@ -131,9 +131,9 @@ def test_calculate_statistics():
             "confidence": 1.0,
         },
     ]
-    
+
     stats = calculate_statistics(entries)
-    
+
     assert stats["total_entries"] == 4
     assert stats["by_type"]["Game"] == 2
     assert stats["by_type"]["Book"] == 1

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -42,104 +42,104 @@ def test_year_propagation():
     assert records[3]["end_date"].startswith("2024-")
 
 
-def test_process_and_save():
-    """Test the end-to-end processing and saving functionality."""
-    # Create mock data
-    csv_content = io.StringIO(
-        """,Notes
-           Jan 1-6 (2023),Started The Hobbit
-           Jan 29-Feb 4,Finished The Hobbit"""
-    )
-    csv_content = "\n".join(
-        [line.strip() for line in csv_content.getvalue().splitlines()]
-    )
+# def test_process_and_save():
+#     """Test the end-to-end processing and saving functionality."""
+#     # Create mock data
+#     csv_content = io.StringIO(
+#         """,Notes
+#            Jan 1-6 (2023),Started The Hobbit
+#            Jan 29-Feb 4,Finished The Hobbit"""
+#     )
+#     csv_content = "\n".join(
+#         [line.strip() for line in csv_content.getvalue().splitlines()]
+#     )
 
-    # Mock dependencies
-    with patch("builtins.open", mock_open()) as mock_file:
-        # Configure the mock to return our CSV content when opened for reading
-        mock_file.return_value.__enter__.return_value.read.return_value = csv_content
+#     # Mock dependencies
+#     with patch("builtins.open", mock_open()) as mock_file:
+#         # Configure the mock to return our CSV content when opened for reading
+#         mock_file.return_value.__enter__.return_value.read.return_value = csv_content
 
-        # Mock the extract_entries function
-        with patch("preprocessing.preprocess.extract_entries") as mock_extract:
-            mock_extract.return_value = [
-                {"title": "The Hobbit", "action": "started", "date": "2023-01-01"},
-                {"title": "The Hobbit", "action": "finished", "date": "2023-02-01"},
-            ]
+#         # Mock the extract_entries function
+#         with patch("preprocessing.preprocess.extract_entries") as mock_extract:
+#             mock_extract.return_value = [
+#                 {"title": "The Hobbit", "action": "started", "date": "2023-01-01"},
+#                 {"title": "The Hobbit", "action": "finished", "date": "2023-02-01"},
+#             ]
 
-            # Mock the apply_tagging function
-            with patch("preprocessing.preprocess.apply_tagging") as mock_tag:
-                mock_tag.return_value = [
-                    {
-                        "title": "The Hobbit",
-                        "canonical_title": "The Hobbit",
-                        "type": "Book",
-                        "action": "started",
-                        "date": "2023-01-01",
-                        "tags": {"genre": ["Fantasy"]},
-                        "confidence": 0.9,
-                    },
-                    {
-                        "title": "The Hobbit",
-                        "canonical_title": "The Hobbit",
-                        "type": "Book",
-                        "action": "finished",
-                        "date": "2023-02-01",
-                        "tags": {"genre": ["Fantasy"]},
-                        "confidence": 0.9,
-                    },
-                ]
+#             # Mock the apply_tagging function
+#             with patch("preprocessing.preprocess.apply_tagging") as mock_tag:
+#                 mock_tag.return_value = [
+#                     {
+#                         "title": "The Hobbit",
+#                         "canonical_title": "The Hobbit",
+#                         "type": "Book",
+#                         "action": "started",
+#                         "date": "2023-01-01",
+#                         "tags": {"genre": ["Fantasy"]},
+#                         "confidence": 0.9,
+#                     },
+#                     {
+#                         "title": "The Hobbit",
+#                         "canonical_title": "The Hobbit",
+#                         "type": "Book",
+#                         "action": "finished",
+#                         "date": "2023-02-01",
+#                         "tags": {"genre": ["Fantasy"]},
+#                         "confidence": 0.9,
+#                     },
+#                 ]
 
-                # Call the function under test
-                stats = process_and_save("input.csv", "output.json")
+#                 # Call the function under test
+#                 stats = process_and_save("input.csv", "output.json")
 
-    # Verify the results
-    assert stats["total_entries"] == 2
-    assert stats["by_type"]["Book"] == 2
-    assert mock_file.call_count > 0  # File was opened
-    assert mock_extract.call_count > 0  # extract_entries was called
-    assert mock_tag.call_count > 0  # apply_tagging was called
+#     # Verify the results
+#     assert stats["total_entries"] == 2
+#     assert stats["by_type"]["Book"] == 2
+#     assert mock_file.call_count > 0  # File was opened
+#     assert mock_extract.call_count > 0  # extract_entries was called
+#     assert mock_tag.call_count > 0  # apply_tagging was called
 
 
-def test_calculate_statistics():
-    """Test the statistics calculation function."""
-    entries = [
-        {
-            "title": "Game A",
-            "type": "Game",
-            "action": "started",
-            "date": "2023-01-01",
-            "confidence": 0.9,
-        },
-        {
-            "title": "Game A",
-            "type": "Game",
-            "action": "finished",
-            "date": "2023-02-01",
-            "confidence": 0.9,
-        },
-        {
-            "title": "Book B",
-            "type": "Book",
-            "action": "started",
-            "date": "2023-03-01",
-            "confidence": 0.4,
-            "warnings": ["Low confidence match"],
-        },
-        {
-            "title": "Movie C",
-            "type": "Movie",
-            "action": "finished",
-            "date": "2023-04-01",
-            "confidence": 1.0,
-        },
-    ]
+# def test_calculate_statistics():
+#     """Test the statistics calculation function."""
+#     entries = [
+#         {
+#             "title": "Game A",
+#             "type": "Game",
+#             "action": "started",
+#             "date": "2023-01-01",
+#             "confidence": 0.9,
+#         },
+#         {
+#             "title": "Game A",
+#             "type": "Game",
+#             "action": "finished",
+#             "date": "2023-02-01",
+#             "confidence": 0.9,
+#         },
+#         {
+#             "title": "Book B",
+#             "type": "Book",
+#             "action": "started",
+#             "date": "2023-03-01",
+#             "confidence": 0.4,
+#             "warnings": ["Low confidence match"],
+#         },
+#         {
+#             "title": "Movie C",
+#             "type": "Movie",
+#             "action": "finished",
+#             "date": "2023-04-01",
+#             "confidence": 1.0,
+#         },
+#     ]
 
-    stats = calculate_statistics(entries)
+#     stats = calculate_statistics(entries)
 
-    assert stats["total_entries"] == 4
-    assert stats["by_type"]["Game"] == 2
-    assert stats["by_type"]["Book"] == 1
-    assert stats["by_type"]["Movie"] == 1
-    assert stats["low_confidence"] == 1
-    assert stats["with_warnings"] == 1
-    assert stats["hint_applied"] == 1
+#     assert stats["total_entries"] == 4
+#     assert stats["by_type"]["Game"] == 2
+#     assert stats["by_type"]["Book"] == 1
+#     assert stats["by_type"]["Movie"] == 1
+#     assert stats["low_confidence"] == 1
+#     assert stats["with_warnings"] == 1
+#     assert stats["hint_applied"] == 1

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,9 +1,12 @@
 """Unit tests for the preprocessing module."""
 
 import io
-from unittest.mock import mock_open, patch
+import json
+from unittest.mock import mock_open, patch, MagicMock
 
-from preprocessing.preprocess import load_weekly_records
+import pytest
+
+from preprocessing.preprocess import load_weekly_records, process_and_save, calculate_statistics
 
 
 def test_year_propagation():
@@ -35,3 +38,106 @@ def test_year_propagation():
         "2024-"
     )  # January continues with new year
     assert records[3]["end_date"].startswith("2024-")
+
+
+def test_process_and_save():
+    """Test the end-to-end processing and saving functionality."""
+    # Create mock data
+    csv_content = io.StringIO(
+        """,Notes
+           Jan 1-6 (2023),Started The Hobbit
+           Jan 29-Feb 4,Finished The Hobbit"""
+    )
+    csv_content = "\n".join(
+        [line.strip() for line in csv_content.getvalue().splitlines()]
+    )
+    
+    # Mock dependencies
+    with patch("builtins.open", mock_open()) as mock_file:
+        # Configure the mock to return our CSV content when opened for reading
+        mock_file.return_value.__enter__.return_value.read.return_value = csv_content
+        
+        # Mock the extract_entries function
+        with patch("preprocessing.preprocess.extract_entries") as mock_extract:
+            mock_extract.return_value = [
+                {"title": "The Hobbit", "action": "started", "date": "2023-01-01"},
+                {"title": "The Hobbit", "action": "finished", "date": "2023-02-01"},
+            ]
+            
+            # Mock the apply_tagging function
+            with patch("preprocessing.preprocess.apply_tagging") as mock_tag:
+                mock_tag.return_value = [
+                    {
+                        "title": "The Hobbit",
+                        "canonical_title": "The Hobbit",
+                        "type": "Book",
+                        "action": "started",
+                        "date": "2023-01-01",
+                        "tags": {"genre": ["Fantasy"]},
+                        "confidence": 0.9,
+                    },
+                    {
+                        "title": "The Hobbit",
+                        "canonical_title": "The Hobbit",
+                        "type": "Book",
+                        "action": "finished",
+                        "date": "2023-02-01",
+                        "tags": {"genre": ["Fantasy"]},
+                        "confidence": 0.9,
+                    },
+                ]
+                
+                # Call the function under test
+                stats = process_and_save("input.csv", "output.json")
+    
+    # Verify the results
+    assert stats["total_entries"] == 2
+    assert stats["by_type"]["Book"] == 2
+    assert mock_file.call_count > 0  # File was opened
+    assert mock_extract.call_count > 0  # extract_entries was called
+    assert mock_tag.call_count > 0  # apply_tagging was called
+
+
+def test_calculate_statistics():
+    """Test the statistics calculation function."""
+    entries = [
+        {
+            "title": "Game A",
+            "type": "Game",
+            "action": "started",
+            "date": "2023-01-01",
+            "confidence": 0.9,
+        },
+        {
+            "title": "Game A",
+            "type": "Game",
+            "action": "finished",
+            "date": "2023-02-01",
+            "confidence": 0.9,
+        },
+        {
+            "title": "Book B",
+            "type": "Book",
+            "action": "started",
+            "date": "2023-03-01",
+            "confidence": 0.4,
+            "warnings": ["Low confidence match"],
+        },
+        {
+            "title": "Movie C",
+            "type": "Movie",
+            "action": "finished",
+            "date": "2023-04-01",
+            "confidence": 1.0,
+        },
+    ]
+    
+    stats = calculate_statistics(entries)
+    
+    assert stats["total_entries"] == 4
+    assert stats["by_type"]["Game"] == 2
+    assert stats["by_type"]["Book"] == 1
+    assert stats["by_type"]["Movie"] == 1
+    assert stats["low_confidence"] == 1
+    assert stats["with_warnings"] == 1
+    assert stats["hint_applied"] == 1

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -5,9 +5,9 @@ from unittest.mock import mock_open, patch
 
 
 from preprocessing.preprocess import (
+    calculate_statistics,
     load_weekly_records,
     process_and_save,
-    calculate_statistics,
 )
 
 
@@ -42,104 +42,98 @@ def test_year_propagation():
     assert records[3]["end_date"].startswith("2024-")
 
 
-# def test_process_and_save():
-#     """Test the end-to-end processing and saving functionality."""
-#     # Create mock data
-#     csv_content = io.StringIO(
-#         """,Notes
-#            Jan 1-6 (2023),Started The Hobbit
-#            Jan 29-Feb 4,Finished The Hobbit"""
-#     )
-#     csv_content = "\n".join(
-#         [line.strip() for line in csv_content.getvalue().splitlines()]
-#     )
+def test_process_and_save():
+    """Test the end-to-end processing and saving functionality."""
+    # Create mock data
+    csv_content = io.StringIO(
+        """,Notes
+           Jan 1-6 (2023),Started The Hobbit
+           Jan 29-Feb 4,Finished The Hobbit"""
+    )
+    csv_content = "\n".join(
+        [line.strip() for line in csv_content.getvalue().splitlines()]
+    )
 
-#     # Mock dependencies
-#     with patch("builtins.open", mock_open()) as mock_file:
-#         # Configure the mock to return our CSV content when opened for reading
-#         mock_file.return_value.__enter__.return_value.read.return_value = csv_content
+    # Mock dependencies
+    with patch("builtins.open", mock_open(read_data=csv_content)), patch(
+        "os.path.exists", return_value=True
+    ), patch("preprocessing.preprocess.extract_entries") as mock_extract, patch(
+        "preprocessing.preprocess.apply_tagging"
+    ) as mock_tag:
+        mock_extract.return_value = [
+            {"title": "The Hobbit", "action": "started", "date": "2023-01-01"},
+            {"title": "The Hobbit", "action": "finished", "date": "2023-02-01"},
+        ]
 
-#         # Mock the extract_entries function
-#         with patch("preprocessing.preprocess.extract_entries") as mock_extract:
-#             mock_extract.return_value = [
-#                 {"title": "The Hobbit", "action": "started", "date": "2023-01-01"},
-#                 {"title": "The Hobbit", "action": "finished", "date": "2023-02-01"},
-#             ]
+        mock_tag.return_value = [
+            {
+                "title": "The Hobbit",
+                "canonical_title": "The Hobbit",
+                "type": "Book",
+                "action": "started",
+                "date": "2023-01-01",
+                "tags": {"genre": ["Fantasy"]},
+                "confidence": 0.9,
+            },
+            {
+                "title": "The Hobbit",
+                "canonical_title": "The Hobbit",
+                "type": "Book",
+                "action": "finished",
+                "date": "2023-02-01",
+                "tags": {"genre": ["Fantasy"]},
+                "confidence": 0.9,
+            },
+        ]
 
-#             # Mock the apply_tagging function
-#             with patch("preprocessing.preprocess.apply_tagging") as mock_tag:
-#                 mock_tag.return_value = [
-#                     {
-#                         "title": "The Hobbit",
-#                         "canonical_title": "The Hobbit",
-#                         "type": "Book",
-#                         "action": "started",
-#                         "date": "2023-01-01",
-#                         "tags": {"genre": ["Fantasy"]},
-#                         "confidence": 0.9,
-#                     },
-#                     {
-#                         "title": "The Hobbit",
-#                         "canonical_title": "The Hobbit",
-#                         "type": "Book",
-#                         "action": "finished",
-#                         "date": "2023-02-01",
-#                         "tags": {"genre": ["Fantasy"]},
-#                         "confidence": 0.9,
-#                     },
-#                 ]
+        # Call the function under test
+        stats = process_and_save("input.csv", "output.json")
 
-#                 # Call the function under test
-#                 stats = process_and_save("input.csv", "output.json")
-
-#     # Verify the results
-#     assert stats["total_entries"] == 2
-#     assert stats["by_type"]["Book"] == 2
-#     assert mock_file.call_count > 0  # File was opened
-#     assert mock_extract.call_count > 0  # extract_entries was called
-#     assert mock_tag.call_count > 0  # apply_tagging was called
+    # Verify the results
+    assert stats["total_entries"] == 2
+    assert stats["by_type"]["Book"] == 2
+    assert mock_extract.call_count > 0  # extract_entries was called
+    assert mock_tag.call_count > 0  # apply_tagging was called
 
 
-# def test_calculate_statistics():
-#     """Test the statistics calculation function."""
-#     entries = [
-#         {
-#             "title": "Game A",
-#             "type": "Game",
-#             "action": "started",
-#             "date": "2023-01-01",
-#             "confidence": 0.9,
-#         },
-#         {
-#             "title": "Game A",
-#             "type": "Game",
-#             "action": "finished",
-#             "date": "2023-02-01",
-#             "confidence": 0.9,
-#         },
-#         {
-#             "title": "Book B",
-#             "type": "Book",
-#             "action": "started",
-#             "date": "2023-03-01",
-#             "confidence": 0.4,
-#             "warnings": ["Low confidence match"],
-#         },
-#         {
-#             "title": "Movie C",
-#             "type": "Movie",
-#             "action": "finished",
-#             "date": "2023-04-01",
-#             "confidence": 1.0,
-#         },
-#     ]
+def test_calculate_statistics():
+    """Test the statistics calculation function."""
+    entries = [
+        {
+            "title": "Game A",
+            "type": "Game",
+            "action": "started",
+            "date": "2023-01-01",
+            "confidence": 0.9,
+        },
+        {
+            "title": "Game A",
+            "type": "Game",
+            "action": "finished",
+            "date": "2023-02-01",
+            "confidence": 0.9,
+        },
+        {
+            "title": "Book B",
+            "type": "Book",
+            "action": "started",
+            "date": "2023-03-01",
+            "confidence": 0.4,
+            "warnings": ["Low confidence match"],
+        },
+        {
+            "title": "Movie C",
+            "type": "Movie",
+            "action": "finished",
+            "date": "2023-04-01",
+            "confidence": 1.0,
+        },
+    ]
 
-#     stats = calculate_statistics(entries)
+    stats = calculate_statistics(entries)
 
-#     assert stats["total_entries"] == 4
-#     assert stats["by_type"]["Game"] == 2
-#     assert stats["by_type"]["Book"] == 1
-#     assert stats["by_type"]["Movie"] == 1
-#     assert stats["low_confidence"] == 1
-#     assert stats["with_warnings"] == 1
-#     assert stats["hint_applied"] == 1
+    assert stats["total_entries"] == 4
+    assert stats["by_type"]["Game"] == 2
+    assert stats["by_type"]["Book"] == 1
+    assert stats["by_type"]["Movie"] == 1
+    assert stats["low_confidence"] == 1

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,12 +1,14 @@
 """Unit tests for the preprocessing module."""
 
 import io
-import json
-from unittest.mock import mock_open, patch, MagicMock
+from unittest.mock import mock_open, patch
 
-import pytest
 
-from preprocessing.preprocess import load_weekly_records, process_and_save, calculate_statistics
+from preprocessing.preprocess import (
+    load_weekly_records,
+    process_and_save,
+    calculate_statistics,
+)
 
 
 def test_year_propagation():

--- a/todo.md
+++ b/todo.md
@@ -26,10 +26,10 @@
 ## 4. API Tagger & Hints Support
 - [x] Create `preprocessing/media_tagger.py`
 - [x] Load `hints.yaml` for manual overrides
-- [ ] Implement stub functions: `query_tmdb`, `query_igdb`, `query_openlibrary`
-- [ ] Write `apply_tagging(entries: List[Dict]) -> List[Dict]`:
-  - [ ] Apply hints first, then API calls
-  - [ ] Attach `type`, `tags` (genre, platform, mood), and `confidence`
+- [x] Implement stub functions: `query_tmdb`, `query_igdb`, `query_openlibrary`
+- [x] Write `apply_tagging(entries: List[Dict]) -> List[Dict]`:
+  - [x] Apply hints first, then API calls
+  - [x] Attach `type`, `tags` (genre, platform, mood), and `confidence`
 - [x] Write tests in `tests/test_media_tagger.py` with mocked API responses and hint overrides
 
 ## 5. JSON Schema & Validation

--- a/todo.md
+++ b/todo.md
@@ -24,13 +24,13 @@
 - [x] Write tests in `tests/test_media_extractor.py` covering various phrasings
 
 ## 4. API Tagger & Hints Support
-- [ ] Create `tagger.py`
-- [ ] Load `hints.yaml` for manual overrides
+- [x] Create `preprocessing/media_tagger.py`
+- [x] Load `hints.yaml` for manual overrides
 - [ ] Implement stub functions: `query_tmdb`, `query_igdb`, `query_openlibrary`
 - [ ] Write `apply_tagging(entries: List[Dict]) -> List[Dict]`:
   - [ ] Apply hints first, then API calls
   - [ ] Attach `type`, `tags` (genre, platform, mood), and `confidence`
-- [ ] Write tests in `tests/test_tagger.py` with mocked API responses and hint overrides
+- [x] Write tests in `tests/test_media_tagger.py` with mocked API responses and hint overrides
 
 ## 5. JSON Schema & Validation
 - [ ] Define `MediaEntry` Pydantic model in `models.py`


### PR DESCRIPTION
Provides support for API tagging and manual hint overrides by creating a new preprocessing module for media tagging. Key changes include:

- Creation of preprocessing/media_tagger.py with stub functions for querying external APIs and applying metadata tagging.
- Updates to tests and prompt plan documentation to reflect the new module.
- Integration of the tagging functionality into the preprocessing pipeline via process_and_save.

Create `preprocessing/media_tagger.py`:
- Load `hints.yaml` for manual overrides.
- Implement stub functions:
  - `query_tmdb(title: str) -> (canonical_title, metadata, confidence)`
  - `query_igdb(...)` and `query_openlibrary(...)`.
- Write `apply_tagging(entries: List[Dict]) -> List[Dict]`:
  - Apply hints first, then API calls.
  - Attach `type`, `tags` (genre, platform, mood), and `confidence`.