### PR TITLE
Impreve media extractor to handle more action text

### DIFF
--- a/preprocessing/media_extractor.py
+++ b/preprocessing/media_extractor.py
@@ -169,7 +169,12 @@ def _extract_entries_from_line(
             titles_str = line[action_len:].strip()
 
             # Entries before 2025 have already been checked and added to IGNORED_ENTRIES where necessary
-            if titles_str and titles_str[0].isalpha() and titles_str[0] == titles_str.lower()[0] and start_date > "2025":
+            if (
+                titles_str
+                and titles_str[0].isalpha()
+                and titles_str[0] == titles_str.lower()[0]
+                and start_date > "2025"
+            ):
                 logger.warning(
                     "Title not capitalized.  This may indicate we missed part of the verb: %s",
                     line,

--- a/preprocessing/media_extractor.py
+++ b/preprocessing/media_extractor.py
@@ -169,7 +169,7 @@ def _extract_entries_from_line(
             titles_str = line[action_len:].strip()
 
             # Entries before 2025 have already been checked and added to IGNORED_ENTRIES where necessary
-            if titles_str[0] == titles_str.lower()[0] and start_date > "2025":
+            if titles_str and titles_str[0].isalpha() and titles_str[0] == titles_str.lower()[0] and start_date > "2025":
                 logger.warning(
                     "Title not capitalized.  This may indicate we missed part of the verb: %s",
                     line,

--- a/preprocessing/media_tagger.py
+++ b/preprocessing/media_tagger.py
@@ -6,7 +6,7 @@ This module includes functions to load hints from YAML and query external APIs.
 import operator
 import os
 import logging
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Optional
 import yaml
 
 logger = logging.getLogger(__name__)

--- a/tests/test_media_extractor.py
+++ b/tests/test_media_extractor.py
@@ -123,7 +123,7 @@ def test_lower_case_titles_before_2025(caplog):
     record = {
         "start_date": "2024-01-01",
         "end_date": "2024-01-07",
-        "raw_notes": "Read 100 Days of Solitude",
+        "raw_notes": "Watched the Clone Wars",
     }
 
     entries = extract_entries(record)
@@ -140,7 +140,7 @@ def test_lower_case_titles_after_2025(caplog):
     record = {
         "start_date": "2025-01-01",
         "end_date": "2025-01-07",
-        "raw_notes": "Read 100 Days of Solitude",
+        "raw_notes": "Watched the Clone Wars",
     }
 
     entries = extract_entries(record)

--- a/tests/test_media_extractor.py
+++ b/tests/test_media_extractor.py
@@ -154,7 +154,7 @@ def test_action_mapping_typo():
 
 def test_action_mapping_restarted():
     """Test that action mapping is correct for different ways of saying restarted."""
-    for verb in ("Good", "Restarted", "Resumed"):
+    for verb in ("Good progress on", "Restarted", "Resumed"):
         record = {
             "start_date": "2023-05-01",
             "end_date": "2023-05-07",


### PR DESCRIPTION
Improves the media entry extraction by handling additional action text and refining title splitting logic, especially when titles contain '&' or ','. Key changes include:

- Renaming and refactoring of ignored actions from IGNORED_VERBS to IGNORED_ENTRIES and updating test cases.
- Enhancements in media_extractor.py to use regex for splitting titles and introduction of the _get_entries helper function.
- Minor cleanup in media_tagger.py by removing an unused Tuple import.

I also noticed some title splitting is problematic is a title containe '&' or ','.  
I'll see about getting feedback to address that once API tagging is implemented