### PR TITLE
Implement the _query_tmdb method in media_tagger.py to fetch the top 5 matching entries from TMDB

### DIFF
--- a/.env_default
+++ b/.env_default
@@ -1,2 +1,2 @@
-# Anthropic API key
 ANTHROPIC_API_KEY=
+TMDB_API_KEY=

--- a/preprocessing/media_apis.py
+++ b/preprocessing/media_apis.py
@@ -1,0 +1,215 @@
+"""
+API client functions for querying external media databases.
+"""
+
+import os
+import logging
+import requests
+import nltk
+
+logger = logging.getLogger(__name__)
+
+# Default paths
+TMDB_BASE_URL = "https://api.themoviedb.org/3"
+GENRE_MAP_BY_MODE = {}
+
+
+def _get_genre_map(mode: str) -> dict:
+    """
+    Get or cache the genre map for a specific TMDB mode (movie or tv).
+    
+    Args:
+        mode: The mode to get genres for ("movie" or "tv")
+        
+    Returns:
+        Dictionary mapping genre IDs to genre names
+    """
+    if mode in GENRE_MAP_BY_MODE:
+        return GENRE_MAP_BY_MODE[mode]
+
+    api_key = os.environ.get("TMDB_API_KEY")
+    genre_response = requests.get(
+        f"{TMDB_BASE_URL}/genre/{mode}/list",
+        params={"api_key": api_key, "language": "en-US"},
+        timeout=10,
+    )
+    genre_response.raise_for_status()
+    genre_data = genre_response.json()
+    genre_map = {g["id"]: g["name"] for g in genre_data.get("genres", [])}
+    GENRE_MAP_BY_MODE[mode] = genre_map
+    return genre_map
+
+
+def query_tmdb(mode: str, title: str) -> list:
+    """
+    Query The Movie Database (TMDB) API for TV shows or Movie metadata.
+
+    Args:
+        mode: The mode of media to query (e.g., "movie" or "tv").
+        title: The title of the media to query.
+
+    Returns:
+        List of dictionaries with metadata for each entry:
+            - canonical_title is the official title from TMDB
+            - poster_path is the URL to the media's poster image
+            - type is the type of media (Movie, TV Show, etc.)
+            - tags is a dictionary containing tags for genre, mood, etc.
+            - confidence is a float between 0 and 1 indicating match confidence
+            - source is the source of the metadata (e.g., "tmdb")
+    """
+    logger.info("Querying TMDB for %s w/ title: %s", mode, title)
+
+    api_key = os.environ.get("TMDB_API_KEY")
+    if not api_key:
+        logger.warning("TMDB_API_KEY not found in environment variables")
+        return []
+
+    results = []
+
+    # Search for TV shows or Movies
+    try:
+        tmdb_response = requests.get(
+            f"{TMDB_BASE_URL}/search/{mode}",
+            params={
+                "api_key": api_key,
+                "query": title,
+                "language": "en-US",
+                "page": 1,
+                "include_adult": "false",
+            },
+            timeout=10,
+        )
+        tmdb_response.raise_for_status()
+        tmdb_data = tmdb_response.json()
+        genre_map = _get_genre_map(mode)
+
+        # Process TMDB results
+        for entry in tmdb_data.get("results", [])[
+            :5
+        ]:  # Get top 5 TV show or Movie matches
+            # Calculate confidence based on popularity and title similarity
+            canonical_title = (
+                entry.get("name", "") if mode == "tv" else entry.get("title", "")
+            )
+
+            title_similarity = 1.0 - (
+                nltk.edit_distance(title.lower(), canonical_title.lower())
+                / max(len(title), len(canonical_title))
+            )
+            popularity = entry.get("popularity", 0) / 100  # Normalize popularity
+            confidence = (
+                0.7 * title_similarity
+                + 0.2 * popularity
+                + 0.1 * min(1.0, entry.get("vote_average", 0) / 10)
+            )
+
+            # Get genre information
+            genres = []
+            if "genre_ids" in entry:
+                genres = [
+                    genre_map.get(gid)
+                    for gid in entry.get("genre_ids", [])
+                    if gid in genre_map
+                ]
+
+            # Create result entry
+            date_key = "first_air_date" if mode == "tv" else "release_date"
+            results.append(
+                {
+                    "canonical_title": canonical_title,
+                    "poster_path": f"https://image.tmdb.org/t/p/w600_and_h900_bestv2/{entry.get('poster_path', '')}",
+                    "type": "TV" if mode == "tv" else "Movie",
+                    "tags": {
+                        "genre": genres,
+                        "release_year": (
+                            entry.get(date_key, "")[:4] if entry.get(date_key) else ""
+                        ),
+                    },
+                    "confidence": confidence,
+                    "source": "tmdb",
+                }
+            )
+
+        # Sort results by confidence
+        results.sort(key=lambda x: x["confidence"], reverse=True)
+        return results[:5]  # Return top 5 results overall
+
+    except requests.RequestException as e:
+        logger.error("Error querying TMDB API for %s: %s", mode, e)
+        return []
+
+
+def query_igdb(title: str) -> list:
+    """
+    Query the Internet Game Database (IGDB) API for video game metadata.
+
+    Args:
+        title: The title of the game to query.
+
+    Returns:
+        List of dictionaries with metadata for each entry:
+            - canonical_title is the official title from IGDB
+            - poster_path is the URL to the media's poster image
+            - type is the type of media (Movie, TV Show, etc.)
+            - tags is a dictionary containing tags for genre, mood, etc.
+            - confidence is a float between 0 and 1 indicating match confidence
+            - source is the source of the metadata (e.g., "igdb")
+    """
+    # This is a stub implementation
+    # In a real implementation, this would make API calls to IGDB
+    logger.info("Querying IGDB for title: %s", title)
+
+    # Simulate API call
+    api_key = os.environ.get("IGDB_API_KEY")
+    if not api_key:
+        logger.warning("IGDB_API_KEY not found in environment variables")
+        return []
+
+    # Mock response - would be replaced with actual API call
+    return [
+        {
+            "canonical_title": title,
+            "type": "Game",
+            "tags": {"platform": ["PC"], "genre": ["RPG"]},
+            "confidence": 0.7,
+            "source": "igdb",
+        }
+    ]
+
+
+def query_openlibrary(title: str) -> list:
+    """
+    Query the Open Library API for book metadata.
+
+    Args:
+        title: The title of the book to query.
+
+    Returns:
+        List of dictionaries with metadata for each entry:
+            - canonical_title is the official title from Open Library
+            - poster_path is the URL to the media's poster image
+            - type is the type of media (Movie, TV Show, etc.)
+            - tags is a dictionary containing tags for genre, mood, etc.
+            - confidence is a float between 0 and 1 indicating match confidence
+            - source is the source of the metadata (e.g., "openlibrary")
+    """
+    # This is a stub implementation
+    # In a real implementation, this would make API calls to Open Library
+    logger.info("Querying Open Library for title: %s", title)
+
+    # Simulate API call
+    api_key = os.environ.get("OPENLIBRARY_API_KEY")
+    if not api_key:
+        logger.warning("OPENLIBRARY_API_KEY not found in environment variables")
+        return []
+
+    # Mock response - would be replaced with actual API call
+    return [
+        {
+            "canonical_title": title,
+            "type": "Book",
+            "tags": {"genre": ["Fiction"]},
+            "confidence": 0.6,
+            "source": "openlibrary",
+        }
+    ]

--- a/preprocessing/media_apis.py
+++ b/preprocessing/media_apis.py
@@ -17,10 +17,10 @@ GENRE_MAP_BY_MODE = {}
 def _get_genre_map(mode: str) -> dict:
     """
     Get or cache the genre map for a specific TMDB mode (movie or tv).
-    
+
     Args:
         mode: The mode to get genres for ("movie" or "tv")
-        
+
     Returns:
         Dictionary mapping genre IDs to genre names
     """

--- a/preprocessing/media_extractor.py
+++ b/preprocessing/media_extractor.py
@@ -4,7 +4,7 @@ Preprocessing stage to extract media entries from the Notes column of a weekly r
 
 import logging
 import re
-from typing import List, Dict
+from typing import Any, Dict, List, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +107,7 @@ def _get_entries(title: str, action: str, start_date: str) -> List[Dict]:
         start_date: The start date of the week.
 
     Returns:
-        entries: A list of dictionaries representing a media entry with the
+        entries: A list of dictionaries where each entry represents a media entry with the
                  following keys:
                     - "action": The action performed (e.g., "finished", "started").
                     - "title": The title of the media item.
@@ -134,7 +134,7 @@ def _get_entries(title: str, action: str, start_date: str) -> List[Dict]:
 
 def _extract_entries_from_line(
     line: str, start_date: str, last_action: str = None
-) -> List[Dict]:
+) -> Tuple[List[Dict[str, Any]], str]:
     """
     Extract media entries from a single line of a weekly record's raw notes.
 
@@ -150,12 +150,13 @@ def _extract_entries_from_line(
         last_action: The action from the previous line, if any.
                      This is used to handle cases where the action is not explicitly stated in the line.
     Returns:
-        entries: A list of dictionaries representing a media entry with the
-                 following keys:
-                    - "action": The action performed (e.g., "finished", "started").
-                    - "title": The title of the media item.
-                    - "date": The start date of the week.
-        action: The action from the current line, which may be used for the next line.
+        Returns a Tuple of entries list and action string
+            - entries: A list of dictionaries representing a media entry with the
+                       following keys:
+                        - "action": The action performed (e.g., "finished", "started").
+                        - "title": The title of the media item.
+                        - "date": The start date of the week.
+            - action: The action from the current line, which may be used for the next line.
     """
     entries = []
     if line in IGNORED_ENTRIES:

--- a/preprocessing/media_tagger.py
+++ b/preprocessing/media_tagger.py
@@ -48,8 +48,6 @@ def _load_hints(hints_path: Optional[str] = DEFAULT_HINTS_PATH) -> Dict:
         return {}
 
 
-
-
 def _combine_votes(
     entry: Dict, api_hits: List[Dict], hint: Optional[Dict] = None
 ) -> Dict:

--- a/preprocessing/media_tagger.py
+++ b/preprocessing/media_tagger.py
@@ -1,23 +1,20 @@
 """
 Preprocessing stage to tag media entries with metadata from external APIs.
-This module includes functions to load hints from YAML and query external APIs.
+This module includes functions to load hints from YAML and apply tagging.
 """
 
 import operator
 import os
 import logging
 from typing import Dict, List, Optional
-import requests
-
-import nltk
 import yaml
+
+from preprocessing.media_apis import query_tmdb, query_igdb, query_openlibrary
 
 logger = logging.getLogger(__name__)
 
 # Default paths
 DEFAULT_HINTS_PATH = os.path.join(os.path.dirname(__file__), "hints.yaml")
-TMDB_BASE_URL = "https://api.themoviedb.org/3"
-GENRE_MAP_BY_MODE = {}
 
 
 def _load_hints(hints_path: Optional[str] = DEFAULT_HINTS_PATH) -> Dict:
@@ -51,196 +48,6 @@ def _load_hints(hints_path: Optional[str] = DEFAULT_HINTS_PATH) -> Dict:
         return {}
 
 
-def _get_genre_map(mode: str) -> Dict[int, str]:
-    if mode in GENRE_MAP_BY_MODE:
-        return GENRE_MAP_BY_MODE[mode]
-
-    api_key = os.environ.get("TMDB_API_KEY")
-    genre_response = requests.get(
-        f"{TMDB_BASE_URL}/genre/{mode}/list",
-        params={"api_key": api_key, "language": "en-US"},
-        timeout=10,
-    )
-    genre_response.raise_for_status()
-    genre_data = genre_response.json()
-    genre_map = {g["id"]: g["name"] for g in genre_data.get("genres", [])}
-    GENRE_MAP_BY_MODE[mode] = genre_map
-    return genre_map
-
-
-def _query_tmdb(mode: str, title: str) -> List[Dict]:
-    """
-    Query The Movie Database (TMDB) API for TV shows or Movie metadata.
-
-    Args:
-        mode: The mode of media to query (e.g., "movie" or "tv").
-        title: The title of the media to query.
-
-    Returns:
-        List of dictionaries with metadata for each entry:
-            - canonical_title is the official title from TMDB
-            - poster_path is the URL to the media's poster image
-            - type is the type of media (Movie, TV Show, etc.)
-            - tags is a dictionary containing tags for genre, mood, etc.
-            - confidence is a float between 0 and 1 indicating match confidence
-            - source is the source of the metadata (e.g., "tmdb")
-    """
-    logger.info("Querying TMDB for %s w/ title: %s", mode, title)
-
-    api_key = os.environ.get("TMDB_API_KEY")
-    if not api_key:
-        logger.warning("TMDB_API_KEY not found in environment variables")
-        return []
-
-    results = []
-
-    # Search for TV shows or Movies
-    try:
-        tmdb_response = requests.get(
-            f"{TMDB_BASE_URL}/search/{mode}",
-            params={
-                "api_key": api_key,
-                "query": title,
-                "language": "en-US",
-                "page": 1,
-                "include_adult": "false",
-            },
-            timeout=10,
-        )
-        tmdb_response.raise_for_status()
-        tmdb_data = tmdb_response.json()
-        genre_map = _get_genre_map(mode)
-
-        # Process TMDB results
-        for entry in tmdb_data.get("results", [])[
-            :5
-        ]:  # Get top 5 TV show or Movie matches
-            # Calculate confidence based on popularity and title similarity
-            canonical_title = (
-                entry.get("name", "") if mode == "tv" else entry.get("title", "")
-            )
-
-            title_similarity = 1.0 - (
-                nltk.edit_distance(title.lower(), canonical_title.lower())
-                / max(len(title), len(canonical_title))
-            )
-            popularity = entry.get("popularity", 0) / 100  # Normalize popularity
-            confidence = (
-                0.7 * title_similarity
-                + 0.2 * popularity
-                + 0.1 * min(1.0, entry.get("vote_average", 0) / 10)
-            )
-
-            # Get genre information
-            genres = []
-            if "genre_ids" in entry:
-                genres = [
-                    genre_map.get(gid)
-                    for gid in entry.get("genre_ids", [])
-                    if gid in genre_map
-                ]
-
-            # Create result entry
-            date_key = "first_air_date" if mode == "tv" else "release_date"
-            results.append(
-                {
-                    "canonical_title": canonical_title,
-                    "poster_path": f"https://image.tmdb.org/t/p/w600_and_h900_bestv2/{entry.get("poster_path", "")}",
-                    "type": "TV" if mode == "tv" else "Movie",
-                    "tags": {
-                        "genre": genres,
-                        "release_year": (
-                            entry.get(date_key, "")[:4] if entry.get(date_key) else ""
-                        ),
-                    },
-                    "confidence": confidence,
-                    "source": "tmdb",
-                }
-            )
-
-        # Sort results by confidence
-        results.sort(key=lambda x: x["confidence"], reverse=True)
-        return results[:5]  # Return top 5 results overall
-
-    except requests.RequestException as e:
-        logger.error("Error querying TMDB API for %s: %s", mode, e)
-        return []
-
-
-def _query_igdb(title: str) -> List[Dict]:
-    """
-    Query the Internet Game Database (IGDB) API for video game metadata.
-
-    Args:
-        title: The title of the game to query.
-
-    Returns:
-        List of dictionaries with metadata for each entry:
-            - canonical_title is the official title from IGDB
-            - poster_path is the URL to the media's poster image
-            - type is the type of media (Movie, TV Show, etc.)
-            - tags is a dictionary containing tags for genre, mood, etc.
-            - confidence is a float between 0 and 1 indicating match confidence
-            - source is the source of the metadata (e.g., "igdb")
-    """
-    # This is a stub implementation
-    # In a real implementation, this would make API calls to IGDB
-    logger.info("Querying IGDB for title: %s", title)
-
-    # Simulate API call
-    api_key = os.environ.get("IGDB_API_KEY")
-    if not api_key:
-        logger.warning("IGDB_API_KEY not found in environment variables")
-        return []
-
-    # Mock response - would be replaced with actual API call
-    return [
-        {
-            "canonical_title": title,
-            "type": "Game",
-            "tags": {"platform": ["PC"], "genre": ["RPG"]},
-            "confidence": 0.7,
-            "source": "igdb",
-        }
-    ]
-
-
-def _query_openlibrary(title: str) -> List[Dict]:
-    """
-    Query the Open Library API for book metadata.
-
-    Args:
-        title: The title of the book to query.
-
-    Returns:
-        List of dictionaries with metadata for each entry:
-            - canonical_title is the official title from Open Library
-            - poster_path is the URL to the media's poster image
-            - type is the type of media (Movie, TV Show, etc.)
-            - tags is a dictionary containing tags for genre, mood, etc.
-            - confidence is a float between 0 and 1 indicating match confidence
-            - source is the source of the metadata (e.g., "openlibrary")
-    """
-    # This is a stub implementation
-    # In a real implementation, this would make API calls to Open Library
-    logger.info("Querying Open Library for title: %s", title)
-
-    # Simulate API call
-    api_key = os.environ.get("OPENLIBRARY_API_KEY")
-    if not api_key:
-        logger.warning("OPENLIBRARY_API_KEY not found in environment variables")
-        return []
-
-    # Mock response - would be replaced with actual API call
-    return [
-        {
-            "canonical_title": title,
-            "type": "Book",
-            "tags": {"genre": ["Fiction"]},
-            "confidence": 0.6,
-            "source": "openlibrary",
-        }
-    ]
 
 
 def _combine_votes(
@@ -342,10 +149,10 @@ def apply_tagging(entries: List[Dict], hints_path: Optional[str] = None) -> List
                 break
 
         api_hits = []
-        api_hits.extend(_query_tmdb("movie", title))
-        api_hits.extend(_query_tmdb("tv", title))
-        api_hits.extend(_query_igdb(title))
-        api_hits.extend(_query_openlibrary(title))
+        api_hits.extend(query_tmdb("movie", title))
+        api_hits.extend(query_tmdb("tv", title))
+        api_hits.extend(query_igdb(title))
+        api_hits.extend(query_openlibrary(title))
 
         # Combine votes from hints and API hits
         tagged_entry = _combine_votes(entry, api_hits, hint)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+nltk==3.9.1
 PyYAML==6.0.2
 pydantic==2.11.4
 requests==2.32.3

--- a/tests/test_media_apis.py
+++ b/tests/test_media_apis.py
@@ -1,0 +1,367 @@
+"""Unit tests for the media API client functions."""
+
+import logging
+import os
+from unittest.mock import patch, MagicMock
+import pytest
+import requests
+
+from preprocessing.media_apis import (
+    query_tmdb,
+    query_igdb,
+    query_openlibrary,
+    _get_genre_map,
+    GENRE_MAP_BY_MODE,
+)
+
+
+@pytest.fixture
+def mock_tmdb_movie_response():
+    """Mock response for TMDB movie search."""
+    return {
+        "results": [
+            {
+                "id": 123,
+                "title": "The Matrix",
+                "release_date": "1999-03-31",
+                "popularity": 50.0,
+                "vote_average": 8.7,
+                "poster_path": "/path/to/poster.jpg",
+                "genre_ids": [28, 878],  # Action, Sci-Fi
+                "overview": "A computer hacker learns about the true nature of reality",
+            },
+            {
+                "id": 456,
+                "title": "The Matrix Reloaded",
+                "release_date": "2003-05-15",
+                "popularity": 40.0,
+                "vote_average": 7.2,
+                "poster_path": "/path/to/poster2.jpg",
+                "genre_ids": [28, 878],
+                "overview": "Neo and the rebels fight against the machines",
+            },
+        ]
+    }
+
+
+@pytest.fixture
+def mock_tmdb_tv_response():
+    """Mock response for TMDB TV search."""
+    return {
+        "results": [
+            {
+                "id": 789,
+                "name": "Stranger Things",
+                "first_air_date": "2016-07-15",
+                "popularity": 80.0,
+                "vote_average": 8.5,
+                "poster_path": "/path/to/poster3.jpg",
+                "genre_ids": [18, 9648, 10765],  # Drama, Mystery, Sci-Fi & Fantasy
+                "overview": "When a young boy disappears, his mother and friends must confront terrifying forces",
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def mock_genre_response():
+    """Mock response for TMDB genre list."""
+    return {
+        "genres": [
+            {"id": 28, "name": "Action"},
+            {"id": 18, "name": "Drama"},
+            {"id": 878, "name": "Science Fiction"},
+            {"id": 9648, "name": "Mystery"},
+            {"id": 10765, "name": "Sci-Fi & Fantasy"},
+        ]
+    }
+
+
+def test_get_genre_map(mock_genre_response):
+    """Test getting and caching the genre map."""
+    # Clear the cache
+    GENRE_MAP_BY_MODE.clear()
+    
+    with patch("requests.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_genre_response
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+        
+        # First call should make the API request
+        genre_map = _get_genre_map("movie")
+        assert mock_get.call_count == 1
+        assert genre_map == {28: "Action", 18: "Drama", 878: "Science Fiction", 
+                            9648: "Mystery", 10765: "Sci-Fi & Fantasy"}
+        
+        # Second call should use the cached value
+        genre_map = _get_genre_map("movie")
+        assert mock_get.call_count == 1
+        
+        # Different mode should make a new request
+        genre_map = _get_genre_map("tv")
+        assert mock_get.call_count == 2
+
+
+def test_query_tmdb_movie_success(mock_tmdb_movie_response, mock_genre_response):
+    """Test successful TMDB movie query."""
+    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), \
+         patch("requests.get") as mock_get:
+        # Set up mock responses
+        def mock_response_side_effect(*args, **kwargs):
+            mock_resp = MagicMock()
+            if "search/movie" in args[0]:
+                mock_resp.json.return_value = mock_tmdb_movie_response
+            elif "genre/movie/list" in args[0]:
+                mock_resp.json.return_value = mock_genre_response
+            mock_resp.raise_for_status.return_value = None
+            return mock_resp
+        
+        mock_get.side_effect = mock_response_side_effect
+        
+        # Call the function
+        results = query_tmdb("movie", "The Matrix")
+        
+        # Verify results
+        assert len(results) == 2
+        assert results[0]["canonical_title"] == "The Matrix"
+        assert results[0]["type"] == "Movie"
+        assert results[0]["tags"]["genre"] == ["Action", "Science Fiction"]
+        assert results[0]["tags"]["release_year"] == "1999"
+        assert results[0]["confidence"] > 0.7  # High confidence for exact match
+        assert results[0]["source"] == "tmdb"
+        assert "poster_path" in results[0]
+
+
+def test_query_tmdb_tv_success(mock_tmdb_tv_response, mock_genre_response):
+    """Test successful TMDB TV query."""
+    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), \
+         patch("requests.get") as mock_get:
+        # Set up mock responses
+        def mock_response_side_effect(*args, **kwargs):
+            mock_resp = MagicMock()
+            if "search/tv" in args[0]:
+                mock_resp.json.return_value = mock_tmdb_tv_response
+            elif "genre/tv/list" in args[0]:
+                mock_resp.json.return_value = mock_genre_response
+            mock_resp.raise_for_status.return_value = None
+            return mock_resp
+        
+        mock_get.side_effect = mock_response_side_effect
+        
+        # Call the function
+        results = query_tmdb("tv", "Stranger Things")
+        
+        # Verify results
+        assert len(results) == 1
+        assert results[0]["canonical_title"] == "Stranger Things"
+        assert results[0]["type"] == "TV"
+        assert "Drama" in results[0]["tags"]["genre"]
+        assert results[0]["tags"]["release_year"] == "2016"
+        assert results[0]["confidence"] > 0.7  # High confidence for exact match
+        assert results[0]["source"] == "tmdb"
+
+
+def test_query_tmdb_no_api_key(caplog):
+    """Test TMDB query with no API key."""
+    with patch.dict(os.environ, {}, clear=True), \
+         caplog.at_level(logging.WARNING):
+        results = query_tmdb("movie", "The Matrix")
+        
+        assert len(results) == 0
+        assert "TMDB_API_KEY not found in environment variables" in caplog.text
+
+
+def test_query_tmdb_empty_results():
+    """Test TMDB query with empty results."""
+    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), \
+         patch("requests.get") as mock_get:
+        # Set up mock responses
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+        
+        # Call the function
+        results = query_tmdb("movie", "NonexistentMovie12345")
+        
+        # Verify results
+        assert len(results) == 0
+
+
+def test_query_tmdb_api_error(caplog):
+    """Test TMDB query with API error."""
+    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), \
+         patch("requests.get") as mock_get, \
+         caplog.at_level(logging.ERROR):
+        # Set up mock to raise an exception
+        mock_get.side_effect = requests.RequestException("API Error")
+        
+        # Call the function
+        results = query_tmdb("movie", "The Matrix")
+        
+        # Verify results
+        assert len(results) == 0
+        assert "Error querying TMDB API for movie: API Error" in caplog.text
+
+
+def test_query_tmdb_confidence_calculation():
+    """Test confidence calculation in TMDB query."""
+    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), \
+         patch("requests.get") as mock_get, \
+         patch("preprocessing.media_apis._get_genre_map", return_value={}):
+        # Create mock responses with varying similarity
+        exact_match = {
+            "results": [
+                {
+                    "title": "Inception",
+                    "popularity": 50.0,
+                    "vote_average": 8.0,
+                    "release_date": "2010-07-16",
+                    "genre_ids": []
+                }
+            ]
+        }
+        
+        similar_match = {
+            "results": [
+                {
+                    "title": "Inceptions",  # Slightly different
+                    "popularity": 50.0,
+                    "vote_average": 8.0,
+                    "release_date": "2010-07-16",
+                    "genre_ids": []
+                }
+            ]
+        }
+        
+        different_match = {
+            "results": [
+                {
+                    "title": "Completely Different Title",
+                    "popularity": 50.0,
+                    "vote_average": 8.0,
+                    "release_date": "2010-07-16",
+                    "genre_ids": []
+                }
+            ]
+        }
+        
+        # Test exact match
+        mock_response = MagicMock()
+        mock_response.json.return_value = exact_match
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+        
+        exact_results = query_tmdb("movie", "Inception")
+        
+        # Test similar match
+        mock_response.json.return_value = similar_match
+        similar_results = query_tmdb("movie", "Inception")
+        
+        # Test different match
+        mock_response.json.return_value = different_match
+        different_results = query_tmdb("movie", "Inception")
+        
+        # Verify confidence scores
+        assert exact_results[0]["confidence"] > similar_results[0]["confidence"]
+        assert similar_results[0]["confidence"] > different_results[0]["confidence"]
+
+
+def test_query_tmdb_sorts_by_confidence():
+    """Test that TMDB query results are sorted by confidence."""
+    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), \
+         patch("requests.get") as mock_get, \
+         patch("preprocessing.media_apis._get_genre_map", return_value={}):
+        # Create mock response with multiple results
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "title": "Star Wars: The Last Jedi",  # Less similar to query
+                    "popularity": 70.0,
+                    "vote_average": 7.0,
+                    "release_date": "2017-12-15",
+                    "genre_ids": []
+                },
+                {
+                    "title": "Star Wars",  # More similar to query
+                    "popularity": 60.0,
+                    "vote_average": 8.0,
+                    "release_date": "1977-05-25",
+                    "genre_ids": []
+                },
+                {
+                    "title": "Star Wars: The Empire Strikes Back",
+                    "popularity": 65.0,
+                    "vote_average": 8.5,
+                    "release_date": "1980-05-21",
+                    "genre_ids": []
+                }
+            ]
+        }
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+        
+        # Call the function
+        results = query_tmdb("movie", "Star Wars")
+        
+        # Verify results are sorted by confidence
+        assert len(results) == 3
+        assert results[0]["canonical_title"] == "Star Wars"  # Most similar should be first
+        assert results[0]["confidence"] > results[1]["confidence"]
+        assert results[1]["confidence"] > results[2]["confidence"]
+
+
+def test_query_tmdb_limits_results():
+    """Test that TMDB query limits results to top 5."""
+    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), \
+         patch("requests.get") as mock_get, \
+         patch("preprocessing.media_apis._get_genre_map", return_value={}):
+        # Create mock response with more than 5 results
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {"title": f"Movie {i}", "popularity": 50.0, "vote_average": 7.0, 
+                 "release_date": "2020-01-01", "genre_ids": []} 
+                for i in range(10)  # 10 results
+            ]
+        }
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+        
+        # Call the function
+        results = query_tmdb("movie", "Movie")
+        
+        # Verify results are limited to 5
+        assert len(results) == 5
+
+
+def test_query_tmdb_handles_missing_fields():
+    """Test that TMDB query handles missing fields gracefully."""
+    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), \
+         patch("requests.get") as mock_get, \
+         patch("preprocessing.media_apis._get_genre_map", return_value={}):
+        # Create mock response with missing fields
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "title": "Movie With Missing Fields",
+                    # Missing: popularity, vote_average, release_date, poster_path
+                    "genre_ids": []
+                }
+            ]
+        }
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+        
+        # Call the function
+        results = query_tmdb("movie", "Movie")
+        
+        # Verify results handle missing fields
+        assert len(results) == 1
+        assert results[0]["canonical_title"] == "Movie With Missing Fields"
+        assert results[0]["tags"]["release_year"] == ""  # Empty string for missing date
+        assert "poster_path" in results[0]  # Should still have the field
+        assert results[0]["confidence"] > 0  # Should still calculate confidence

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -150,10 +150,10 @@ def test_apply_tagging_with_only_hints(sample_entries, sample_hints):
 
     with patch("builtins.open", mock_open(read_data=mock_yaml_content)), patch(
         "os.path.exists", return_value=True
-    ), patch("preprocessing.media_tagger._query_tmdb"), patch(
-        "preprocessing.media_tagger._query_igdb"
+    ), patch("preprocessing.media_tagger.query_tmdb"), patch(
+        "preprocessing.media_tagger.query_igdb"
     ), patch(
-        "preprocessing.media_tagger._query_openlibrary"
+        "preprocessing.media_tagger.query_openlibrary"
     ):
         tagged_entries = apply_tagging(sample_entries, "fake_path.yaml")
 
@@ -173,9 +173,9 @@ def test_apply_tagging_with_api_calls(sample_entries):
         entry for entry in sample_entries if entry["title"] == "Succesion"
     ]
     with patch("preprocessing.media_tagger._load_hints", return_value={}), patch(
-        "preprocessing.media_apis.query_tmdb"
-    ) as mock_tmdb, patch("preprocessing.media_apis.query_igdb") as mock_igdb, patch(
-        "preprocessing.media_apis.query_openlibrary"
+        "preprocessing.media_tagger.query_tmdb"
+    ) as mock_tmdb, patch("preprocessing.media_tagger.query_igdb") as mock_igdb, patch(
+        "preprocessing.media_tagger.query_openlibrary"
     ) as mock_openlibrary:
         # Set up mock returns
         mock_tmdb.return_value = [
@@ -227,10 +227,10 @@ def test_apply_tagging_api_failure(sample_entries, caplog):
 
     with caplog.at_level(logging.WARNING), patch(
         "preprocessing.media_tagger._load_hints", return_value={}
-    ), patch("preprocessing.media_apis.query_tmdb", return_value=[]), patch(
-        "preprocessing.media_apis.query_igdb", return_value=[]
+    ), patch("preprocessing.media_tagger.query_tmdb", return_value=[]), patch(
+        "preprocessing.media_tagger.query_igdb", return_value=[]
     ), patch(
-        "preprocessing.media_apis.query_openlibrary",
+        "preprocessing.media_tagger.query_openlibrary",
         return_value=[],
     ):
         tagged_entries = apply_tagging(ff7_entry)
@@ -252,9 +252,9 @@ def test_apply_tagging_with_api_calls_and_hints(sample_entries):
     # Mock the API calls
     succession_entry = [entry for entry in sample_entries if entry["title"] == "FF7"]
     with patch("preprocessing.media_tagger._load_hints", return_value={}), patch(
-        "preprocessing.media_apis.query_tmdb"
-    ) as mock_tmdb, patch("preprocessing.media_apis.query_igdb") as mock_igdb, patch(
-        "preprocessing.media_apis.query_openlibrary"
+        "preprocessing.media_tagger.query_tmdb"
+    ) as mock_tmdb, patch("preprocessing.media_tagger.query_igdb") as mock_igdb, patch(
+        "preprocessing.media_tagger.query_openlibrary"
     ) as mock_openlibrary:
         # Set up mock returns
         mock_tmdb.return_value = [
@@ -304,10 +304,10 @@ def test_apply_tagging_with_narrow_confidence(sample_entries, caplog):
     hobbit_entry = [entry for entry in sample_entries if entry["title"] == "The Hobbit"]
     with caplog.at_level(logging.WARNING), patch(
         "preprocessing.media_tagger._load_hints", return_value={}
-    ), patch("preprocessing.media_apis.query_tmdb") as mock_tmdb, patch(
-        "preprocessing.media_apis.query_igdb"
+    ), patch("preprocessing.media_tagger.query_tmdb") as mock_tmdb, patch(
+        "preprocessing.media_tagger.query_igdb"
     ) as mock_igdb, patch(
-        "preprocessing.media_apis.query_openlibrary"
+        "preprocessing.media_tagger.query_openlibrary"
     ) as mock_openlibrary:
         # Set up mock returns
         mock_tmdb.return_value = [
@@ -356,12 +356,10 @@ def test_apply_tagging_fix_confidence_with_hint(sample_entries, caplog):
     hobbit_entry = [entry for entry in sample_entries if entry["title"] == "The Hobbit"]
     with caplog.at_level(logging.WARNING), patch(
         "preprocessing.media_tagger._load_hints"
-    ) as mock_hints, patch(
-        "preprocessing.media_apis.query_tmdb"
-    ) as mock_tmdb, patch(
-        "preprocessing.media_apis.query_igdb"
+    ) as mock_hints, patch("preprocessing.media_tagger.query_tmdb") as mock_tmdb, patch(
+        "preprocessing.media_tagger.query_igdb"
     ) as mock_igdb, patch(
-        "preprocessing.media_apis.query_openlibrary"
+        "preprocessing.media_tagger.query_openlibrary"
     ) as mock_openlibrary:
         # Set up mock returns
         mock_hints.return_value = {
@@ -420,10 +418,10 @@ def test_apply_tagging_with_low_confidence(sample_entries, caplog):
     ff7_entry = [entry for entry in sample_entries if entry["title"] == "FF7"]
     with caplog.at_level(logging.WARNING), patch(
         "preprocessing.media_tagger._load_hints", return_value={}
-    ), patch("preprocessing.media_apis.query_tmdb") as mock_tmdb, patch(
-        "preprocessing.media_apis.query_igdb"
+    ), patch("preprocessing.media_tagger.query_tmdb") as mock_tmdb, patch(
+        "preprocessing.media_tagger.query_igdb"
     ) as mock_igdb, patch(
-        "preprocessing.media_apis.query_openlibrary"
+        "preprocessing.media_tagger.query_openlibrary"
     ) as mock_openlibrary:
         # Set up mock returns
         mock_tmdb.return_value = []

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -9,10 +9,12 @@ import pytest
 
 from preprocessing.media_tagger import (
     _load_hints,
-    _query_tmdb,
-    _query_igdb,
-    _query_openlibrary,
     apply_tagging,
+)
+from preprocessing.media_apis import (
+    query_tmdb,
+    query_igdb,
+    query_openlibrary,
 )
 
 
@@ -87,7 +89,7 @@ def test_load_hints_invalid_yaml():
 def test_query_tmdb():
     """Test querying TMDB API."""
     with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}):
-        api_hits = _query_tmdb("movie", "The Matrix")
+        api_hits = query_tmdb("movie", "The Matrix")
 
     # Since this is a stub, we're just checking the structure
     assert api_hits is not None
@@ -99,7 +101,7 @@ def test_query_tmdb():
 def test_query_tmdb_no_api_key(caplog):
     """Test querying TMDB API with no API key."""
     with caplog.at_level(logging.WARNING), patch.dict(os.environ, {}, clear=True):
-        api_hits = _query_tmdb("movie", "The Matrix")
+        api_hits = query_tmdb("movie", "The Matrix")
 
     assert "TMDB_API_KEY not found in environment variables" in caplog.text
     assert not api_hits
@@ -108,7 +110,7 @@ def test_query_tmdb_no_api_key(caplog):
 def test_query_igdb():
     """Test querying IGDB API."""
     with patch.dict(os.environ, {"IGDB_API_KEY": "fake_key"}):
-        api_hits = _query_igdb("Elden Ring")
+        api_hits = query_igdb("Elden Ring")
 
     # Since this is a stub, we're just checking the structure
     assert api_hits is not None
@@ -120,7 +122,7 @@ def test_query_igdb():
 def test_query_openlibrary():
     """Test querying Open Library API."""
     with patch.dict(os.environ, {"OPENLIBRARY_API_KEY": "fake_key"}):
-        api_hits = _query_openlibrary("The Hobbit")
+        api_hits = query_openlibrary("The Hobbit")
 
     # Since this is a stub, we're just checking the structure
     assert api_hits is not None
@@ -171,9 +173,9 @@ def test_apply_tagging_with_api_calls(sample_entries):
         entry for entry in sample_entries if entry["title"] == "Succesion"
     ]
     with patch("preprocessing.media_tagger._load_hints", return_value={}), patch(
-        "preprocessing.media_tagger._query_tmdb"
-    ) as mock_tmdb, patch("preprocessing.media_tagger._query_igdb") as mock_igdb, patch(
-        "preprocessing.media_tagger._query_openlibrary"
+        "preprocessing.media_apis.query_tmdb"
+    ) as mock_tmdb, patch("preprocessing.media_apis.query_igdb") as mock_igdb, patch(
+        "preprocessing.media_apis.query_openlibrary"
     ) as mock_openlibrary:
         # Set up mock returns
         mock_tmdb.return_value = [
@@ -225,10 +227,10 @@ def test_apply_tagging_api_failure(sample_entries, caplog):
 
     with caplog.at_level(logging.WARNING), patch(
         "preprocessing.media_tagger._load_hints", return_value={}
-    ), patch("preprocessing.media_tagger._query_tmdb", return_value=[]), patch(
-        "preprocessing.media_tagger._query_igdb", return_value=[]
+    ), patch("preprocessing.media_apis.query_tmdb", return_value=[]), patch(
+        "preprocessing.media_apis.query_igdb", return_value=[]
     ), patch(
-        "preprocessing.media_tagger._query_openlibrary",
+        "preprocessing.media_apis.query_openlibrary",
         return_value=[],
     ):
         tagged_entries = apply_tagging(ff7_entry)
@@ -250,9 +252,9 @@ def test_apply_tagging_with_api_calls_and_hints(sample_entries):
     # Mock the API calls
     succession_entry = [entry for entry in sample_entries if entry["title"] == "FF7"]
     with patch("preprocessing.media_tagger._load_hints", return_value={}), patch(
-        "preprocessing.media_tagger._query_tmdb"
-    ) as mock_tmdb, patch("preprocessing.media_tagger._query_igdb") as mock_igdb, patch(
-        "preprocessing.media_tagger._query_openlibrary"
+        "preprocessing.media_apis.query_tmdb"
+    ) as mock_tmdb, patch("preprocessing.media_apis.query_igdb") as mock_igdb, patch(
+        "preprocessing.media_apis.query_openlibrary"
     ) as mock_openlibrary:
         # Set up mock returns
         mock_tmdb.return_value = [
@@ -302,10 +304,10 @@ def test_apply_tagging_with_narrow_confidence(sample_entries, caplog):
     hobbit_entry = [entry for entry in sample_entries if entry["title"] == "The Hobbit"]
     with caplog.at_level(logging.WARNING), patch(
         "preprocessing.media_tagger._load_hints", return_value={}
-    ), patch("preprocessing.media_tagger._query_tmdb") as mock_tmdb, patch(
-        "preprocessing.media_tagger._query_igdb"
+    ), patch("preprocessing.media_apis.query_tmdb") as mock_tmdb, patch(
+        "preprocessing.media_apis.query_igdb"
     ) as mock_igdb, patch(
-        "preprocessing.media_tagger._query_openlibrary"
+        "preprocessing.media_apis.query_openlibrary"
     ) as mock_openlibrary:
         # Set up mock returns
         mock_tmdb.return_value = [
@@ -355,11 +357,11 @@ def test_apply_tagging_fix_confidence_with_hint(sample_entries, caplog):
     with caplog.at_level(logging.WARNING), patch(
         "preprocessing.media_tagger._load_hints"
     ) as mock_hints, patch(
-        "preprocessing.media_tagger._query_tmdb"
+        "preprocessing.media_apis.query_tmdb"
     ) as mock_tmdb, patch(
-        "preprocessing.media_tagger._query_igdb"
+        "preprocessing.media_apis.query_igdb"
     ) as mock_igdb, patch(
-        "preprocessing.media_tagger._query_openlibrary"
+        "preprocessing.media_apis.query_openlibrary"
     ) as mock_openlibrary:
         # Set up mock returns
         mock_hints.return_value = {
@@ -418,10 +420,10 @@ def test_apply_tagging_with_low_confidence(sample_entries, caplog):
     ff7_entry = [entry for entry in sample_entries if entry["title"] == "FF7"]
     with caplog.at_level(logging.WARNING), patch(
         "preprocessing.media_tagger._load_hints", return_value={}
-    ), patch("preprocessing.media_tagger._query_tmdb") as mock_tmdb, patch(
-        "preprocessing.media_tagger._query_igdb"
+    ), patch("preprocessing.media_apis.query_tmdb") as mock_tmdb, patch(
+        "preprocessing.media_apis.query_igdb"
     ) as mock_igdb, patch(
-        "preprocessing.media_tagger._query_openlibrary"
+        "preprocessing.media_apis.query_openlibrary"
     ) as mock_openlibrary:
         # Set up mock returns
         mock_tmdb.return_value = []


### PR DESCRIPTION
Refactors the media tagging functionality by replacing the stub API query function query_tmdb with actual API client implementations and updating the associated tests. 

Key changes include:
- Making HTTP requests to the TMDB API and processing the responses to extract relevant metadata.
- Replacing internal query* functions with new query_* functions from preprocessing/media_apis.py.
- Updating test cases in tests/test_media_tagger.py to patch and call the new API functions.
- Minor refactoring and type hint updates in preprocessing/media_extractor.py for clearer return types.
