### PR TITLE
Reset token before each IGDB login test

### DIFF
--- a/tests/test_media_apis.py
+++ b/tests/test_media_apis.py
@@ -18,6 +18,13 @@ from preprocessing.media_apis import (
 )
 
 
+@pytest.fixture(autouse=True)
+def reset_igdb_token():
+    """Reset IGDB token before each test to ensure consistent state."""
+    media_apis.IGDB_TOKEN = None
+    yield
+
+
 @pytest.fixture(name="mock_tmdb_movie_response")
 def fixture_mock_tmdb_movie_response():
     """Mock response for TMDB movie search."""
@@ -418,8 +425,6 @@ def test_calculate_title_similarity():
 
 def test_get_igdb_token_success(mock_igdb_auth_response):
     """Test successful IGDB token retrieval."""
-    media_apis.IGDB_TOKEN = None  # Reset token for the test
-
     with patch.dict(
         os.environ,
         {
@@ -442,8 +447,6 @@ def test_get_igdb_token_success(mock_igdb_auth_response):
 
 def test_get_igdb_token_missing_credentials(caplog):
     """Test IGDB token retrieval with missing credentials."""
-    media_apis.IGDB_TOKEN = None  # Reset token for the test
-
     with patch.dict(os.environ, {}, clear=True), caplog.at_level(logging.WARNING):
         token = _get_igdb_token()
 
@@ -453,8 +456,6 @@ def test_get_igdb_token_missing_credentials(caplog):
 
 def test_get_igdb_token_api_error(caplog):
     """Test IGDB token retrieval with API error."""
-    media_apis.IGDB_TOKEN = None  # Reset token for the test
-
     with patch.dict(
         os.environ,
         {

--- a/tests/test_media_apis.py
+++ b/tests/test_media_apis.py
@@ -6,6 +6,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 import requests
 
+from preprocessing import media_apis
 from preprocessing.media_apis import (
     query_tmdb,
     query_igdb,
@@ -417,6 +418,8 @@ def test_calculate_title_similarity():
 
 def test_get_igdb_token_success(mock_igdb_auth_response):
     """Test successful IGDB token retrieval."""
+    media_apis.IGDB_TOKEN = None  # Reset token for the test
+
     with patch.dict(
         os.environ,
         {
@@ -439,6 +442,8 @@ def test_get_igdb_token_success(mock_igdb_auth_response):
 
 def test_get_igdb_token_missing_credentials(caplog):
     """Test IGDB token retrieval with missing credentials."""
+    media_apis.IGDB_TOKEN = None  # Reset token for the test
+
     with patch.dict(os.environ, {}, clear=True), caplog.at_level(logging.WARNING):
         token = _get_igdb_token()
 
@@ -448,6 +453,8 @@ def test_get_igdb_token_missing_credentials(caplog):
 
 def test_get_igdb_token_api_error(caplog):
     """Test IGDB token retrieval with API error."""
+    media_apis.IGDB_TOKEN = None  # Reset token for the test
+
     with patch.dict(
         os.environ,
         {


### PR DESCRIPTION
Ensures that the global IGDB_TOKEN is cleared before each IGDB-related login test to avoid state leakage between tests.