### PR TITLE
Avoid splitting titles that are listed in hints.yaml

### DIFF
--- a/preprocessing/media_extractor.py
+++ b/preprocessing/media_extractor.py
@@ -3,10 +3,10 @@ Preprocessing stage to extract media entries from the Notes column of a weekly r
 """
 
 import logging
-import os
 import re
-import yaml
 from typing import Any, Dict, List, Optional, Tuple
+
+from preprocessing.utils import load_hints
 
 logger = logging.getLogger(__name__)
 
@@ -60,25 +60,6 @@ ALL_VERBS = (
 )
 
 
-def _load_hints(hints_path: Optional[str] = None) -> Dict:
-    """
-    Load hints from YAML file.
-    
-    Args:
-        hints_path: Path to the hints YAML file. If None, uses default path.
-        
-    Returns:
-        Dictionary of hints.
-    """
-    if not hints_path:
-        hints_path = os.path.join(os.path.dirname(__file__), "hints.yaml")
-    
-    try:
-        with open(hints_path, "r") as f:
-            return yaml.safe_load(f) or {}
-    except (FileNotFoundError, yaml.YAMLError) as e:
-        logger.warning("Failed to load hints file: %s", e)
-        return {}
 
 
 def extract_entries(record: Dict, hints_path: Optional[str] = None) -> List[Dict]:
@@ -104,7 +85,7 @@ def extract_entries(record: Dict, hints_path: Optional[str] = None) -> List[Dict
         return entries
 
     # Load hints to avoid splitting titles that contain & or ,
-    hints = _load_hints(hints_path)
+    hints = load_hints(hints_path)
     
     # Get all hint titles and aliases that might contain & or ,
     protected_titles = []

--- a/preprocessing/media_tagger.py
+++ b/preprocessing/media_tagger.py
@@ -4,7 +4,6 @@ This module includes functions to apply tagging with metadata from APIs and hint
 """
 
 import operator
-import os
 import logging
 from typing import Dict, List, Optional
 
@@ -12,11 +11,6 @@ from preprocessing.media_apis import query_tmdb, query_igdb, query_openlibrary
 from preprocessing.utils import load_hints
 
 logger = logging.getLogger(__name__)
-
-# Default paths
-DEFAULT_HINTS_PATH = os.path.join(os.path.dirname(__file__), "hints.yaml")
-
-
 
 
 def _combine_votes(

--- a/preprocessing/media_tagger.py
+++ b/preprocessing/media_tagger.py
@@ -1,15 +1,15 @@
 """
 Preprocessing stage to tag media entries with metadata from external APIs.
-This module includes functions to load hints from YAML and apply tagging.
+This module includes functions to apply tagging with metadata from APIs and hints.
 """
 
 import operator
 import os
 import logging
 from typing import Dict, List, Optional
-import yaml
 
 from preprocessing.media_apis import query_tmdb, query_igdb, query_openlibrary
+from preprocessing.utils import load_hints
 
 logger = logging.getLogger(__name__)
 
@@ -17,35 +17,6 @@ logger = logging.getLogger(__name__)
 DEFAULT_HINTS_PATH = os.path.join(os.path.dirname(__file__), "hints.yaml")
 
 
-def _load_hints(hints_path: Optional[str] = DEFAULT_HINTS_PATH) -> Dict:
-    """
-    Load hints from a YAML file for manual overrides.
-
-    Args:
-        hints_path: Path to the hints YAML file.
-
-    Returns:
-        Dictionary containing hints for media entries.
-    """
-    if hints_path is None:
-        hints_path = DEFAULT_HINTS_PATH
-    if not os.path.exists(hints_path):
-        logger.warning(
-            "Hints file not found at %s. No manual overrides will be applied.",
-            hints_path,
-        )
-        return {}
-
-    try:
-        with open(hints_path, "r", encoding="utf-8") as file:
-            hints = yaml.safe_load(file)
-            if not hints:
-                return {}
-            logger.info("Loaded %d hints from %s", len(hints), hints_path)
-            return hints
-    except (yaml.YAMLError, IOError) as e:
-        logger.error("Error loading hints file: %s", e)
-        return {}
 
 
 def _combine_votes(
@@ -129,7 +100,7 @@ def apply_tagging(entries: List[Dict], hints_path: Optional[str] = None) -> List
     Returns:
         List of dictionaries with added metadata: canonical_title, type, tags, confidence.
     """
-    hints = _load_hints(hints_path)
+    hints = load_hints(hints_path)
     tagged_entries = []
 
     for entry in entries:

--- a/preprocessing/utils.py
+++ b/preprocessing/utils.py
@@ -1,0 +1,42 @@
+"""
+Shared utility functions for preprocessing modules.
+"""
+
+import logging
+import os
+from typing import Dict, Optional
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+def load_hints(hints_path: Optional[str] = None) -> Dict:
+    """
+    Load hints from a YAML file for manual overrides.
+
+    Args:
+        hints_path: Path to the hints YAML file. If None, uses default path.
+
+    Returns:
+        Dictionary containing hints for media entries.
+    """
+    if hints_path is None:
+        hints_path = os.path.join(os.path.dirname(__file__), "hints.yaml")
+        
+    if not os.path.exists(hints_path):
+        logger.warning(
+            "Hints file not found at %s. No manual overrides will be applied.",
+            hints_path,
+        )
+        return {}
+
+    try:
+        with open(hints_path, "r", encoding="utf-8") as file:
+            hints = yaml.safe_load(file)
+            if not hints:
+                return {}
+            logger.info("Loaded %d hints from %s", len(hints), hints_path)
+            return hints
+    except (yaml.YAMLError, IOError, FileNotFoundError) as e:
+        logger.warning("Failed to load hints file: %s", e)
+        return {}

--- a/preprocessing/utils.py
+++ b/preprocessing/utils.py
@@ -8,6 +8,7 @@ from typing import Dict, Optional
 import yaml
 
 logger = logging.getLogger(__name__)
+DEFAULT_HINTS_PATH = os.path.join(os.path.dirname(__file__), "hints.yaml")
 
 
 def load_hints(hints_path: Optional[str] = None) -> Dict:
@@ -21,8 +22,8 @@ def load_hints(hints_path: Optional[str] = None) -> Dict:
         Dictionary containing hints for media entries.
     """
     if hints_path is None:
-        hints_path = os.path.join(os.path.dirname(__file__), "hints.yaml")
-        
+        hints_path = DEFAULT_HINTS_PATH
+
     if not os.path.exists(hints_path):
         logger.warning(
             "Hints file not found at %s. No manual overrides will be applied.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+"""Common test fixtures"""
+
+import pytest
+
+
+@pytest.fixture()
+def sample_hints():
+    """Sample hints data for testing."""
+    return {
+        "FF7": {
+            "canonical_title": "Final Fantasy VII Remake",
+            "type": "Game",
+            "tags": {
+                "platform": ["PS5"],
+                "genre": ["JRPG", "Adventure"],
+                "mood": ["Epic"],
+            },
+        },
+        "LOTR": {
+            "canonical_title": "The Lord of the Rings",
+            "type": "Book",
+            "tags": {
+                "genre": ["Fantasy"],
+                "mood": ["Epic"],
+            },
+        },
+    }

--- a/tests/test_media_extractor.py
+++ b/tests/test_media_extractor.py
@@ -209,23 +209,25 @@ def test_protected_titles_from_hints():
     # Create a temporary hints file with a title containing &
     import tempfile
     import yaml
-    
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as temp_file:
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as temp_file:
         hints_data = {
             "Dungeons & Dragons": {
                 "canonical_title": "Dungeons & Dragons",
                 "type": "Game",
-                "tags": {"genre": ["RPG"]}
+                "tags": {"genre": ["RPG"]},
             },
             "Command & Conquer": {
                 "canonical_title": "Command & Conquer",
                 "type": "Game",
-                "tags": {"genre": ["Strategy"]}
-            }
+                "tags": {"genre": ["Strategy"]},
+            },
         }
         yaml.dump(hints_data, temp_file)
         temp_hints_path = temp_file.name
-    
+
     try:
         # Test with a title that contains &
         record = {
@@ -235,7 +237,7 @@ def test_protected_titles_from_hints():
         }
 
         entries = extract_entries(record, hints_path=temp_hints_path)
-        
+
         # Should have 2 entries, not 4 (which would happen if & in titles were split)
         assert len(entries) == 2
         assert entries[0]["title"] == "Dungeons & Dragons"
@@ -243,4 +245,5 @@ def test_protected_titles_from_hints():
     finally:
         # Clean up the temporary file
         import os
+
         os.unlink(temp_hints_path)

--- a/tests/test_media_extractor.py
+++ b/tests/test_media_extractor.py
@@ -11,7 +11,7 @@ def test_extract_single_entry():
         "raw_notes": "Started The Hobbit",
     }
 
-    entries = extract_entries(record)
+    entries = extract_entries(record, hints_path=None)
 
     assert len(entries) == 1
     assert entries[0]["action"] == "started"
@@ -27,7 +27,7 @@ def test_extract_multiple_entries():
         "raw_notes": "Started Elden Ring & Cyberpunk 2077",
     }
 
-    entries = extract_entries(record)
+    entries = extract_entries(record, hints_path=None)
 
     assert len(entries) == 2
 
@@ -48,7 +48,7 @@ def test_extract_entries_with_newlines():
         "raw_notes": "Finished The Last of Us\nStarted Hogwarts Legacy",
     }
 
-    entries = extract_entries(record)
+    entries = extract_entries(record, hints_path=None)
 
     assert len(entries) == 2
 
@@ -77,7 +77,7 @@ def test_single_week_action_phrasings():
             "raw_notes": raw_text,
         }
 
-        entries = extract_entries(record)
+        entries = extract_entries(record, hints_path=None)
 
         assert len(entries) == 2
         assert entries[0]["title"] == expected_title
@@ -93,13 +93,13 @@ def test_empty_or_invalid_record():
     # Empty raw_notes
     record = {"start_date": "2023-06-01", "end_date": "2023-06-07", "raw_notes": ""}
 
-    entries = extract_entries(record)
+    entries = extract_entries(record, hints_path=None)
     assert len(entries) == 0
 
     # Missing dates
     record = {"raw_notes": "Started Final Fantasy XVI"}
 
-    entries = extract_entries(record)
+    entries = extract_entries(record, hints_path=None)
     assert len(entries) == 0
 
 
@@ -113,7 +113,7 @@ def test_ignored_actions():
             "raw_notes": f"{verb}",
         }
 
-        entries = extract_entries(record)
+        entries = extract_entries(record, hints_path=None)
 
     assert len(entries) == 0
 
@@ -126,7 +126,7 @@ def test_lower_case_titles_before_2025(caplog):
         "raw_notes": "Watched the Clone Wars",
     }
 
-    entries = extract_entries(record)
+    entries = extract_entries(record, hints_path=None)
 
     assert (
         f"Title not capitalized.  This may indicate we missed part of the verb: {record['raw_notes']}"
@@ -143,7 +143,7 @@ def test_lower_case_titles_after_2025(caplog):
         "raw_notes": "Watched the Clone Wars",
     }
 
-    entries = extract_entries(record)
+    entries = extract_entries(record, hints_path=None)
 
     assert (
         f"Title not capitalized.  This may indicate we missed part of the verb: {record['raw_notes']}"
@@ -160,7 +160,7 @@ def test_action_mapping_typo():
         "raw_notes": "Finshed The Witcher 3",
     }
 
-    entries = extract_entries(record)
+    entries = extract_entries(record, hints_path=None)
 
     assert len(entries) == 1
     assert entries[0]["action"] == "finished"
@@ -177,7 +177,7 @@ def test_action_mapping_restarted():
             "raw_notes": f"{verb} The Witcher 3",
         }
 
-        entries = extract_entries(record)
+        entries = extract_entries(record, hints_path=None)
 
         assert len(entries) == 1
         assert entries[0]["action"] == "started"
@@ -193,7 +193,7 @@ def test_action_continuing_line():
         "raw_notes": "Finished The Witcher 3\n& Frostpunk",
     }
 
-    entries = extract_entries(record)
+    entries = extract_entries(record, hints_path=None)
 
     assert len(entries) == 2
     assert entries[0]["action"] == "finished"

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -134,7 +134,7 @@ def test_apply_tagging_missing_title(caplog):
     entries = [{"action": "started", "date": "2023-01-01"}]  # Missing title
 
     with caplog.at_level(logging.WARNING), patch(
-        "preprocessing.media_tagger._load_hints", return_value={}
+        "preprocessing.utils.load_hints", return_value={}
     ):
         tagged_entries = apply_tagging(entries)
 
@@ -353,7 +353,7 @@ def test_apply_tagging_fix_confidence_with_hint(sample_entries, caplog):
     # Mock the API calls
     hobbit_entry = [entry for entry in sample_entries if entry["title"] == "The Hobbit"]
     with caplog.at_level(logging.WARNING), patch(
-        "preprocessing.media_tagger._load_hints"
+        "preprocessing.utils.load_hints"
     ) as mock_hints, patch("preprocessing.media_tagger.query_tmdb") as mock_tmdb, patch(
         "preprocessing.media_tagger.query_igdb"
     ) as mock_igdb, patch(
@@ -415,7 +415,7 @@ def test_apply_tagging_with_low_confidence(sample_entries, caplog):
     # Mock the API calls
     ff7_entry = [entry for entry in sample_entries if entry["title"] == "FF7"]
     with caplog.at_level(logging.WARNING), patch(
-        "preprocessing.media_tagger._load_hints", return_value={}
+        "preprocessing.utils.load_hints", return_value={}
     ), patch("preprocessing.media_tagger.query_tmdb") as mock_tmdb, patch(
         "preprocessing.media_tagger.query_igdb"
     ) as mock_igdb, patch(

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -8,36 +8,11 @@ import yaml
 import pytest
 
 from preprocessing.media_tagger import apply_tagging
-from preprocessing.utils import load_hints
 from preprocessing.media_apis import (
     query_tmdb,
     query_igdb,
     query_openlibrary,
 )
-
-
-@pytest.fixture(name="sample_hints")
-def fixture_sample_hints():
-    """Sample hints data for testing."""
-    return {
-        "FF7": {
-            "canonical_title": "Final Fantasy VII Remake",
-            "type": "Game",
-            "tags": {
-                "platform": ["PS5"],
-                "genre": ["JRPG", "Adventure"],
-                "mood": ["Epic"],
-            },
-        },
-        "LOTR": {
-            "canonical_title": "The Lord of the Rings",
-            "type": "Book",
-            "tags": {
-                "genre": ["Fantasy"],
-                "mood": ["Epic"],
-            },
-        },
-    }
 
 
 @pytest.fixture(name="sample_entries")
@@ -48,40 +23,6 @@ def fixture_sample_entries():
         {"title": "The Hobbit", "action": "finished", "date": "2023-02-15"},
         {"title": "Succesion", "action": "started", "date": "2023-03-10"},
     ]
-
-
-def test_load_hints_success(sample_hints):
-    """Test loading hints from a YAML file successfully."""
-    mock_yaml_content = yaml.dump(sample_hints)
-
-    with patch("builtins.open", mock_open(read_data=mock_yaml_content)), patch(
-        "os.path.exists", return_value=True
-    ):
-        hints = load_hints("fake_path.yaml")
-
-    assert hints == sample_hints
-    assert "FF7" in hints
-    assert hints["FF7"]["canonical_title"] == "Final Fantasy VII Remake"
-
-
-def test_load_hints_file_not_found():
-    """Test handling when hints file is not found."""
-    with patch("os.path.exists", return_value=False):
-        hints = load_hints("nonexistent_file.yaml")
-
-    assert hints == {}
-
-
-def test_load_hints_invalid_yaml():
-    """Test handling invalid YAML content."""
-    invalid_yaml = "invalid: yaml: content: - ["
-
-    with patch("builtins.open", mock_open(read_data=invalid_yaml)), patch(
-        "os.path.exists", return_value=True
-    ):
-        hints = load_hints("invalid.yaml")
-
-    assert hints == {}
 
 
 def test_query_tmdb():
@@ -134,7 +75,7 @@ def test_apply_tagging_missing_title(caplog):
     entries = [{"action": "started", "date": "2023-01-01"}]  # Missing title
 
     with caplog.at_level(logging.WARNING), patch(
-        "preprocessing.utils.load_hints", return_value={}
+        "preprocessing.media_tagger.load_hints", return_value={}
     ):
         tagged_entries = apply_tagging(entries)
 
@@ -170,7 +111,7 @@ def test_apply_tagging_with_api_calls(sample_entries):
     succession_entry = [
         entry for entry in sample_entries if entry["title"] == "Succesion"
     ]
-    with patch("preprocessing.utils.load_hints", return_value={}), patch(
+    with patch("preprocessing.media_tagger.load_hints", return_value={}), patch(
         "preprocessing.media_tagger.query_tmdb"
     ) as mock_tmdb, patch("preprocessing.media_tagger.query_igdb") as mock_igdb, patch(
         "preprocessing.media_tagger.query_openlibrary"
@@ -224,7 +165,7 @@ def test_apply_tagging_api_failure(sample_entries, caplog):
     ff7_entry = [entry for entry in sample_entries if entry["title"] == "FF7"]
 
     with caplog.at_level(logging.WARNING), patch(
-        "preprocessing.media_tagger._load_hints", return_value={}
+        "preprocessing.media_tagger.load_hints", return_value={}
     ), patch("preprocessing.media_tagger.query_tmdb", return_value=[]), patch(
         "preprocessing.media_tagger.query_igdb", return_value=[]
     ), patch(
@@ -249,7 +190,7 @@ def test_apply_tagging_with_api_calls_and_hints(sample_entries):
     """Test applying tagging with API hits and hints."""
     # Mock the API calls
     succession_entry = [entry for entry in sample_entries if entry["title"] == "FF7"]
-    with patch("preprocessing.utils.load_hints", return_value={}), patch(
+    with patch("preprocessing.media_tagger.load_hints", return_value={}), patch(
         "preprocessing.media_tagger.query_tmdb"
     ) as mock_tmdb, patch("preprocessing.media_tagger.query_igdb") as mock_igdb, patch(
         "preprocessing.media_tagger.query_openlibrary"
@@ -301,7 +242,7 @@ def test_apply_tagging_with_narrow_confidence(sample_entries, caplog):
     # Mock the API calls
     hobbit_entry = [entry for entry in sample_entries if entry["title"] == "The Hobbit"]
     with caplog.at_level(logging.WARNING), patch(
-        "preprocessing.media_tagger._load_hints", return_value={}
+        "preprocessing.media_tagger.load_hints", return_value={}
     ), patch("preprocessing.media_tagger.query_tmdb") as mock_tmdb, patch(
         "preprocessing.media_tagger.query_igdb"
     ) as mock_igdb, patch(
@@ -353,7 +294,7 @@ def test_apply_tagging_fix_confidence_with_hint(sample_entries, caplog):
     # Mock the API calls
     hobbit_entry = [entry for entry in sample_entries if entry["title"] == "The Hobbit"]
     with caplog.at_level(logging.WARNING), patch(
-        "preprocessing.utils.load_hints"
+        "preprocessing.media_tagger.load_hints"
     ) as mock_hints, patch("preprocessing.media_tagger.query_tmdb") as mock_tmdb, patch(
         "preprocessing.media_tagger.query_igdb"
     ) as mock_igdb, patch(
@@ -415,7 +356,7 @@ def test_apply_tagging_with_low_confidence(sample_entries, caplog):
     # Mock the API calls
     ff7_entry = [entry for entry in sample_entries if entry["title"] == "FF7"]
     with caplog.at_level(logging.WARNING), patch(
-        "preprocessing.utils.load_hints", return_value={}
+        "preprocessing.media_tagger.load_hints", return_value={}
     ), patch("preprocessing.media_tagger.query_tmdb") as mock_tmdb, patch(
         "preprocessing.media_tagger.query_igdb"
     ) as mock_igdb, patch(

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -7,10 +7,8 @@ import yaml
 
 import pytest
 
-from preprocessing.media_tagger import (
-    _load_hints,
-    apply_tagging,
-)
+from preprocessing.media_tagger import apply_tagging
+from preprocessing.utils import load_hints
 from preprocessing.media_apis import (
     query_tmdb,
     query_igdb,
@@ -59,7 +57,7 @@ def test_load_hints_success(sample_hints):
     with patch("builtins.open", mock_open(read_data=mock_yaml_content)), patch(
         "os.path.exists", return_value=True
     ):
-        hints = _load_hints("fake_path.yaml")
+        hints = load_hints("fake_path.yaml")
 
     assert hints == sample_hints
     assert "FF7" in hints
@@ -69,7 +67,7 @@ def test_load_hints_success(sample_hints):
 def test_load_hints_file_not_found():
     """Test handling when hints file is not found."""
     with patch("os.path.exists", return_value=False):
-        hints = _load_hints("nonexistent_file.yaml")
+        hints = load_hints("nonexistent_file.yaml")
 
     assert hints == {}
 
@@ -81,7 +79,7 @@ def test_load_hints_invalid_yaml():
     with patch("builtins.open", mock_open(read_data=invalid_yaml)), patch(
         "os.path.exists", return_value=True
     ):
-        hints = _load_hints("invalid.yaml")
+        hints = load_hints("invalid.yaml")
 
     assert hints == {}
 
@@ -172,7 +170,7 @@ def test_apply_tagging_with_api_calls(sample_entries):
     succession_entry = [
         entry for entry in sample_entries if entry["title"] == "Succesion"
     ]
-    with patch("preprocessing.media_tagger._load_hints", return_value={}), patch(
+    with patch("preprocessing.utils.load_hints", return_value={}), patch(
         "preprocessing.media_tagger.query_tmdb"
     ) as mock_tmdb, patch("preprocessing.media_tagger.query_igdb") as mock_igdb, patch(
         "preprocessing.media_tagger.query_openlibrary"
@@ -251,7 +249,7 @@ def test_apply_tagging_with_api_calls_and_hints(sample_entries):
     """Test applying tagging with API hits and hints."""
     # Mock the API calls
     succession_entry = [entry for entry in sample_entries if entry["title"] == "FF7"]
-    with patch("preprocessing.media_tagger._load_hints", return_value={}), patch(
+    with patch("preprocessing.utils.load_hints", return_value={}), patch(
         "preprocessing.media_tagger.query_tmdb"
     ) as mock_tmdb, patch("preprocessing.media_tagger.query_igdb") as mock_igdb, patch(
         "preprocessing.media_tagger.query_openlibrary"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,41 @@
+"""Unit tests for loading the hints file."""
+
+from unittest.mock import patch, mock_open
+
+import yaml
+
+from preprocessing.utils import load_hints
+
+
+def test_load_hints_success(sample_hints):
+    """Test loading hints from a YAML file successfully."""
+    mock_yaml_content = yaml.dump(sample_hints)
+
+    with patch("builtins.open", mock_open(read_data=mock_yaml_content)), patch(
+        "os.path.exists", return_value=True
+    ):
+        hints = load_hints("fake_path.yaml")
+
+    assert hints == sample_hints
+    assert "FF7" in hints
+    assert hints["FF7"]["canonical_title"] == "Final Fantasy VII Remake"
+
+
+def test_load_hints_file_not_found():
+    """Test handling when hints file is not found."""
+    with patch("os.path.exists", return_value=False):
+        hints = load_hints("nonexistent_file.yaml")
+
+    assert hints == {}
+
+
+def test_load_hints_invalid_yaml():
+    """Test handling invalid YAML content."""
+    invalid_yaml = "invalid: yaml: content: - ["
+
+    with patch("builtins.open", mock_open(read_data=invalid_yaml)), patch(
+        "os.path.exists", return_value=True
+    ):
+        hints = load_hints("invalid.yaml")
+
+    assert hints == {}

--- a/todo.md
+++ b/todo.md
@@ -22,7 +22,7 @@
 - [x] Detect actions (`started`, `finished`, `watched`) using regex or spaCy
 - [x] Return entries with `title`, `action`, and `date`
 - [x] Write tests in `tests/test_media_extractor.py` covering various phrasings
-- [ ] Handle titles with an "&" or "," in the name
+- [x] Handle titles with an "&" or "," in the name
 
 ## 4. API Tagger & Hints Support
 - [x] Create `preprocessing/media_tagger.py`
@@ -34,7 +34,7 @@
 - [x] Write tests in `tests/test_media_tagger.py` with mocked API responses and hint overrides
 - [x] Implement `query_tmdb`
 - [x] Implement `query_igdb`
-- [ ] Implement `query_openlibrary`
+- [x] Implement `query_openlibrary`
 - [ ] Batch titles to minimize requests to the APIs
 - [ ] Trim seasons
 - [ ] Use hints to limit the DBs queried for a title


### PR DESCRIPTION
Avoid splitting titles that are listed in hints.yaml, you could modify the extract_entries function in media_extractor.py to check if a potential split would break a known title from the hints file.

- First, load the hints from hints.yaml at the beginning of the extraction process
- Before splitting on `&` or `,`, check if the current text contains any titles from the hints file
- If a hint title is found and would be broken by splitting, preserve that part of the text