### PR TITLE
Only query the relevant media DB API if a hint specifies the media type

### DIFF
--- a/preprocessing/media_tagger.py
+++ b/preprocessing/media_tagger.py
@@ -112,10 +112,25 @@ def apply_tagging(entries: List[Dict], hints_path: Optional[str] = None) -> List
                 break
 
         api_hits = []
-        api_hits.extend(query_tmdb("movie", title))
-        api_hits.extend(query_tmdb("tv", title))
-        api_hits.extend(query_igdb(title))
-        api_hits.extend(query_openlibrary(title))
+        # If hint specifies the type, only query the appropriate database
+        if hint and "type" in hint:
+            media_type = hint["type"]
+            if media_type == "Movie":
+                api_hits.extend(query_tmdb("movie", title))
+            elif media_type == "TV":
+                api_hits.extend(query_tmdb("tv", title))
+            elif media_type == "Game":
+                api_hits.extend(query_igdb(title))
+            elif media_type == "Book":
+                api_hits.extend(query_openlibrary(title))
+            else:
+                logger.warning("Unknown media type in hint: %s", media_type)
+        else:
+            # No hint or no type specified, query all databases
+            api_hits.extend(query_tmdb("movie", title))
+            api_hits.extend(query_tmdb("tv", title))
+            api_hits.extend(query_igdb(title))
+            api_hits.extend(query_openlibrary(title))
 
         # Combine votes from hints and API hits
         tagged_entry = _combine_votes(entry, api_hits, hint)

--- a/preprocessing/media_tagger.py
+++ b/preprocessing/media_tagger.py
@@ -112,24 +112,17 @@ def apply_tagging(entries: List[Dict], hints_path: Optional[str] = None) -> List
                 break
 
         api_hits = []
+        types_to_query = ["Movie", "TV", "Game", "Book"]
         # If hint specifies the type, only query the appropriate database
         if hint and "type" in hint:
-            media_type = hint["type"]
-            if media_type == "Movie":
-                api_hits.extend(query_tmdb("movie", title))
-            elif media_type == "TV":
-                api_hits.extend(query_tmdb("tv", title))
-            elif media_type == "Game":
-                api_hits.extend(query_igdb(title))
-            elif media_type == "Book":
-                api_hits.extend(query_openlibrary(title))
-            else:
-                logger.warning("Unknown media type in hint: %s", media_type)
-        else:
-            # No hint or no type specified, query all databases
+            types_to_query = [hint["type"]]
+        if "Movie" in types_to_query:
             api_hits.extend(query_tmdb("movie", title))
+        if "TV" in types_to_query:
             api_hits.extend(query_tmdb("tv", title))
+        if "Game" in types_to_query:
             api_hits.extend(query_igdb(title))
+        if "Book" in types_to_query:
             api_hits.extend(query_openlibrary(title))
 
         # Combine votes from hints and API hits

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -389,3 +389,88 @@ def test_apply_tagging_with_low_confidence(sample_entries, caplog):
     assert tagged_entry["type"] == "Game"
     assert tagged_entry["confidence"] == 0.2
     assert tagged_entry["source"] == "igdb"
+
+
+def test_apply_tagging_only_queries_specified_type(sample_entries):
+    """Test that only the appropriate API is queried when hint specifies the type."""
+    # Create entries for each media type
+    movie_entry = [{"title": "Matrix", "action": "watched", "date": "2023-01-01"}]
+    tv_entry = [{"title": "Succession", "action": "watched", "date": "2023-01-01"}]
+    game_entry = [{"title": "Elden", "action": "played", "date": "2023-01-01"}]
+    book_entry = [{"title": "LOTR", "action": "read", "date": "2023-01-01"}]
+    
+    # Test Movie type
+    with patch("preprocessing.media_tagger.load_hints") as mock_hints, patch(
+        "preprocessing.media_tagger.query_tmdb"
+    ) as mock_tmdb, patch(
+        "preprocessing.media_tagger.query_igdb"
+    ) as mock_igdb, patch(
+        "preprocessing.media_tagger.query_openlibrary"
+    ) as mock_openlibrary:
+        # Set up mock hint for Movie
+        mock_hints.return_value = {"Matrix": {"type": "Movie"}}
+        mock_tmdb.return_value = [{"canonical_title": "The Matrix", "type": "Movie", "confidence": 0.9, "source": "tmdb", "tags": {}}]
+        
+        apply_tagging(movie_entry)
+        
+        # Verify only movie API was called
+        mock_tmdb.assert_called_once_with("movie", "Matrix")
+        mock_igdb.assert_not_called()
+        mock_openlibrary.assert_not_called()
+    
+    # Test TV type
+    with patch("preprocessing.media_tagger.load_hints") as mock_hints, patch(
+        "preprocessing.media_tagger.query_tmdb"
+    ) as mock_tmdb, patch(
+        "preprocessing.media_tagger.query_igdb"
+    ) as mock_igdb, patch(
+        "preprocessing.media_tagger.query_openlibrary"
+    ) as mock_openlibrary:
+        # Set up mock hint for TV
+        mock_hints.return_value = {"Succession": {"type": "TV"}}
+        mock_tmdb.return_value = [{"canonical_title": "Succession", "type": "TV", "confidence": 0.9, "source": "tmdb", "tags": {}}]
+        
+        apply_tagging(tv_entry)
+        
+        # Verify only TV API was called
+        mock_tmdb.assert_called_once_with("tv", "Succession")
+        mock_igdb.assert_not_called()
+        mock_openlibrary.assert_not_called()
+    
+    # Test Game type
+    with patch("preprocessing.media_tagger.load_hints") as mock_hints, patch(
+        "preprocessing.media_tagger.query_tmdb"
+    ) as mock_tmdb, patch(
+        "preprocessing.media_tagger.query_igdb"
+    ) as mock_igdb, patch(
+        "preprocessing.media_tagger.query_openlibrary"
+    ) as mock_openlibrary:
+        # Set up mock hint for Game
+        mock_hints.return_value = {"Elden": {"type": "Game"}}
+        mock_igdb.return_value = [{"canonical_title": "Elden Ring", "type": "Game", "confidence": 0.9, "source": "igdb", "tags": {}}]
+        
+        apply_tagging(game_entry)
+        
+        # Verify only game API was called
+        mock_tmdb.assert_not_called()
+        mock_igdb.assert_called_once_with("Elden")
+        mock_openlibrary.assert_not_called()
+    
+    # Test Book type
+    with patch("preprocessing.media_tagger.load_hints") as mock_hints, patch(
+        "preprocessing.media_tagger.query_tmdb"
+    ) as mock_tmdb, patch(
+        "preprocessing.media_tagger.query_igdb"
+    ) as mock_igdb, patch(
+        "preprocessing.media_tagger.query_openlibrary"
+    ) as mock_openlibrary:
+        # Set up mock hint for Book
+        mock_hints.return_value = {"LOTR": {"type": "Book"}}
+        mock_openlibrary.return_value = [{"canonical_title": "The Lord of the Rings", "type": "Book", "confidence": 0.9, "source": "openlibrary", "tags": {}}]
+        
+        apply_tagging(book_entry)
+        
+        # Verify only book API was called
+        mock_tmdb.assert_not_called()
+        mock_igdb.assert_not_called()
+        mock_openlibrary.assert_called_once_with("LOTR")

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -391,85 +391,99 @@ def test_apply_tagging_with_low_confidence(sample_entries, caplog):
     assert tagged_entry["source"] == "igdb"
 
 
-def test_apply_tagging_only_queries_specified_type(sample_entries):
+def test_apply_tagging_only_queries_specified_type():
     """Test that only the appropriate API is queried when hint specifies the type."""
     # Create entries for each media type
     movie_entry = [{"title": "Matrix", "action": "watched", "date": "2023-01-01"}]
     tv_entry = [{"title": "Succession", "action": "watched", "date": "2023-01-01"}]
     game_entry = [{"title": "Elden", "action": "played", "date": "2023-01-01"}]
     book_entry = [{"title": "LOTR", "action": "read", "date": "2023-01-01"}]
-    
-    # Test Movie type
+
     with patch("preprocessing.media_tagger.load_hints") as mock_hints, patch(
         "preprocessing.media_tagger.query_tmdb"
-    ) as mock_tmdb, patch(
-        "preprocessing.media_tagger.query_igdb"
-    ) as mock_igdb, patch(
+    ) as mock_tmdb, patch("preprocessing.media_tagger.query_igdb") as mock_igdb, patch(
         "preprocessing.media_tagger.query_openlibrary"
     ) as mock_openlibrary:
-        # Set up mock hint for Movie
+
+        def reset_mocks():
+            mock_tmdb.reset_mock()
+            mock_igdb.reset_mock()
+            mock_openlibrary.reset_mock()
+
+        # Test Movie type
         mock_hints.return_value = {"Matrix": {"type": "Movie"}}
-        mock_tmdb.return_value = [{"canonical_title": "The Matrix", "type": "Movie", "confidence": 0.9, "source": "tmdb", "tags": {}}]
-        
+        mock_tmdb.return_value = [
+            {
+                "canonical_title": "The Matrix",
+                "type": "Movie",
+                "confidence": 0.9,
+                "source": "tmdb",
+                "tags": {},
+            }
+        ]
+
         apply_tagging(movie_entry)
-        
+
         # Verify only movie API was called
         mock_tmdb.assert_called_once_with("movie", "Matrix")
         mock_igdb.assert_not_called()
         mock_openlibrary.assert_not_called()
-    
-    # Test TV type
-    with patch("preprocessing.media_tagger.load_hints") as mock_hints, patch(
-        "preprocessing.media_tagger.query_tmdb"
-    ) as mock_tmdb, patch(
-        "preprocessing.media_tagger.query_igdb"
-    ) as mock_igdb, patch(
-        "preprocessing.media_tagger.query_openlibrary"
-    ) as mock_openlibrary:
-        # Set up mock hint for TV
+
+        # Test TV type
+        reset_mocks()
         mock_hints.return_value = {"Succession": {"type": "TV"}}
-        mock_tmdb.return_value = [{"canonical_title": "Succession", "type": "TV", "confidence": 0.9, "source": "tmdb", "tags": {}}]
-        
+        mock_tmdb.return_value = [
+            {
+                "canonical_title": "Succession",
+                "type": "TV",
+                "confidence": 0.9,
+                "source": "tmdb",
+                "tags": {},
+            }
+        ]
+
         apply_tagging(tv_entry)
-        
+
         # Verify only TV API was called
         mock_tmdb.assert_called_once_with("tv", "Succession")
         mock_igdb.assert_not_called()
         mock_openlibrary.assert_not_called()
-    
-    # Test Game type
-    with patch("preprocessing.media_tagger.load_hints") as mock_hints, patch(
-        "preprocessing.media_tagger.query_tmdb"
-    ) as mock_tmdb, patch(
-        "preprocessing.media_tagger.query_igdb"
-    ) as mock_igdb, patch(
-        "preprocessing.media_tagger.query_openlibrary"
-    ) as mock_openlibrary:
-        # Set up mock hint for Game
+
+        # Test Game type
+        reset_mocks()
         mock_hints.return_value = {"Elden": {"type": "Game"}}
-        mock_igdb.return_value = [{"canonical_title": "Elden Ring", "type": "Game", "confidence": 0.9, "source": "igdb", "tags": {}}]
-        
+        mock_igdb.return_value = [
+            {
+                "canonical_title": "Elden Ring",
+                "type": "Game",
+                "confidence": 0.9,
+                "source": "igdb",
+                "tags": {},
+            }
+        ]
+
         apply_tagging(game_entry)
-        
+
         # Verify only game API was called
         mock_tmdb.assert_not_called()
         mock_igdb.assert_called_once_with("Elden")
         mock_openlibrary.assert_not_called()
-    
-    # Test Book type
-    with patch("preprocessing.media_tagger.load_hints") as mock_hints, patch(
-        "preprocessing.media_tagger.query_tmdb"
-    ) as mock_tmdb, patch(
-        "preprocessing.media_tagger.query_igdb"
-    ) as mock_igdb, patch(
-        "preprocessing.media_tagger.query_openlibrary"
-    ) as mock_openlibrary:
-        # Set up mock hint for Book
+
+        # Test Book type
+        reset_mocks()
         mock_hints.return_value = {"LOTR": {"type": "Book"}}
-        mock_openlibrary.return_value = [{"canonical_title": "The Lord of the Rings", "type": "Book", "confidence": 0.9, "source": "openlibrary", "tags": {}}]
-        
+        mock_openlibrary.return_value = [
+            {
+                "canonical_title": "The Lord of the Rings",
+                "type": "Book",
+                "confidence": 0.9,
+                "source": "openlibrary",
+                "tags": {},
+            }
+        ]
+
         apply_tagging(book_entry)
-        
+
         # Verify only book API was called
         mock_tmdb.assert_not_called()
         mock_igdb.assert_not_called()

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -392,7 +392,10 @@ def test_apply_tagging_with_low_confidence(sample_entries, caplog):
 
 
 def test_apply_tagging_only_queries_specified_type():
-    """Test that only the appropriate API is queried when hint specifies the type."""
+    """
+    Test that only the appropriate API is queried when hint specifies the type.
+    This minimizes unnecessary API calls and improves performance.
+    """
     # Create entries for each media type
     movie_entry = [{"title": "Matrix", "action": "watched", "date": "2023-01-01"}]
     tv_entry = [{"title": "Succession", "action": "watched", "date": "2023-01-01"}]

--- a/todo.md
+++ b/todo.md
@@ -37,7 +37,7 @@
 - [x] Implement `query_openlibrary`
 - [ ] Batch titles to minimize requests to the APIs
 - [ ] Trim seasons
-- [ ] Use hints to limit the DBs queried for a title
+- [x] Use hints to limit the DBs queried for a title
 
 ## 5. JSON Schema & Validation
 - [ ] Define `MediaEntry` Pydantic model in `models.py`


### PR DESCRIPTION
Optimizes media API queries by limiting them to only the relevant database when a media type hint is provided.

- Updated the todo checklist to mark the hint-based limitation as completed.
- Added tests to verify that only the appropriate API is called based on the hint’s media type.
- Modified the apply_tagging function to conditionally query only the specified API.

If a hint is already specifying the media `type` we don't need to query all the DBs.  Just query the one for the specified type.