### PR TITLE
Add hints and E2E test the system for the media tagging system.

### DIFF
--- a/preprocessing/hints.yaml
+++ b/preprocessing/hints.yaml
@@ -9,50 +9,67 @@
 #     mood: ["Mood1", "Mood2"]
 
 # Video Games
+BioShock:
+  canonical_title: "BioShock"
+  type: "Game"
+
 FF7:
   canonical_title: "Final Fantasy VII Remake"
   type: "Game"
-  tags:
-    platform: ["PS5"]
-    genre: ["JRPG", "Adventure"]
-    mood: ["Epic"]
 
-Elden:
-  canonical_title: "Elden Ring"
+Hades:
+  canonical_title: "Hades"
   type: "Game"
-  tags:
-    platform: ["PS5", "PC"]
-    genre: ["Action RPG", "Open World"]
-    mood: ["Dark Fantasy"]
+
+The Avengers:
+  canonical_title: "Marvel's Avengers"
+  type: "Game"
+
+The Avengers w/ Danyi:
+  canonical_title: "Marvel's Avengers"
+  type: "Game"
 
 # Books
 LOTR:
   canonical_title: "The Lord of the Rings"
   type: "Book"
-  tags:
-    genre: ["Fantasy"]
-    mood: ["Epic"]
 
 Hobbit:
   canonical_title: "The Hobbit"
   type: "Book"
-  tags:
-    genre: ["Fantasy"]
-    mood: ["Adventure"]
 
 # TV Shows
-Succession:
-  canonical_title: "Succession"
+Captain Falcon & the Winter Soldier:
+  canonical_title: "The Falcon and the Winter Soldier"
   type: "TV Show"
-  tags:
-    genre: ["Drama"]
-    platform: ["HBO"]
-    mood: ["Dark"]
+
+Finished WandaVision:
+  canonical_title: "WandaVision"
+  type: "TV Show"
+
+Snowpiercer:
+  canonical_title: "Snowpiercer"
+  type: "TV Show"
+
+Star Trek Discovery:
+  canonical_title: "Star Trek: Discovery"
+  type: "TV Show"
 
 # Movies
 Matrix:
   canonical_title: "The Matrix"
   type: "Movie"
-  tags:
-    genre: ["Sci-Fi", "Action"]
-    mood: ["Philosophical"]
+
+# Other
+Ant Design:
+  type: "Software Development"
+
+BackstopJS:
+  type: "Software Development"
+
+React Native Paper:
+  type: "Software Development"
+
+Todo App testing:
+  canonical_title: "Chalk Project"
+  type: "Software Development"

--- a/preprocessing/media_tagger.py
+++ b/preprocessing/media_tagger.py
@@ -3,7 +3,6 @@ Preprocessing stage to tag media entries with metadata from external APIs.
 This module includes functions to apply tagging with metadata from APIs and hints.
 """
 
-import operator
 import logging
 import re
 from typing import Dict, List, Optional
@@ -117,7 +116,7 @@ def _tag_entry(entry: Dict, hints: Dict) -> Dict:
     for hint_key, hint_data in hints.items():
         if hint_key == title:
             logger.info("Applying hint for '%s' to entry '%s'", hint_key, entry)
-            title = hint_data["canonical_title"]
+            title = hint_data.get("canonical_title", title)
             hint = hint_data
             break
 

--- a/preprocessing/preprocess.py
+++ b/preprocessing/preprocess.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
     logging.basicConfig(
         level=logging.WARN,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        filename="preprocess.log",
+        filename="preprocessing/processed_data/preprocess.log",
         filemode="w",
     )
 
@@ -139,7 +139,7 @@ if __name__ == "__main__":
     final_stats = process_and_save(
         "preprocessing/raw_data/media_enjoyed.csv",
         "preprocessing/processed_data/media_entries.json",
-        limit=100,
+        limit=20,
     )
 
     # Print statistics

--- a/tests/test_media_apis.py
+++ b/tests/test_media_apis.py
@@ -2,8 +2,6 @@
 
 import logging
 import os
-import datetime
-import time
 from unittest.mock import patch, MagicMock
 import pytest
 import requests
@@ -347,37 +345,6 @@ def test_query_tmdb_handles_missing_fields():
         assert len(results) == 0
 
 
-def test_query_tmdb_with_future_release():
-    """Test TMDB query with a future release date."""
-    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), patch(
-        "requests.get"
-    ) as mock_get, patch("preprocessing.media_apis._get_genre_map", return_value={}):
-        # Create mock response with future release date
-        future_date = (datetime.datetime.now() + datetime.timedelta(days=365)).strftime("%Y-%m-%d")
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "results": [
-                {
-                    "title": "Future Movie",
-                    "popularity": 50.0,
-                    "vote_average": 0.0,
-                    "release_date": future_date,
-                    "genre_ids": [28],
-                }
-            ]
-        }
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
-
-        # Call the function
-        results = query_tmdb("movie", "Future")
-
-        # Verify that results with future release dates are included
-        assert len(results) == 1
-        assert results[0]["canonical_title"] == "Future Movie"
-        assert results[0]["tags"]["release_year"] == future_date[:4]
-
-
 @pytest.fixture(name="mock_igdb_auth_response")
 def fixture_mock_igdb_auth_response():
     """Mock response for IGDB authentication."""
@@ -537,26 +504,6 @@ def test_format_igdb_entry_missing_fields():
 
     # Results without a first_release_date should not be included
     assert result is None
-
-
-def test_format_igdb_entry_future_release():
-    """Test formatting an IGDB game entry with a future release date."""
-    # Use a date far in the future to ensure the test doesn't break over time
-    future_timestamp = int(time.time()) + 31536000  # One year in the future
-    
-    game = {
-        "name": "Future Game",
-        "first_release_date": future_timestamp,
-        "genres": [{"name": "RPG"}],
-        "platforms": [{"name": "PC"}],
-    }
-
-    result = _format_igdb_entry("Future Game", game)
-    
-    # Should still include future releases as long as they have a date
-    assert result is not None
-    assert result["canonical_title"] == "Future Game"
-    assert result["tags"]["release_year"] == time.strftime("%Y", time.gmtime(future_timestamp))
 
 
 def test_format_igdb_entry_partial_fields():
@@ -752,36 +699,6 @@ def test_query_openlibrary_missing_fields():
 
         # Verify results handle missing a first_publish_year are omitted
         assert len(results) == 0
-
-
-def test_query_openlibrary_future_publication():
-    """Test OpenLibrary query with a future publication date."""
-    next_year = datetime.datetime.now().year + 1
-    
-    with patch("requests.get") as mock_get:
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "numFound": 1,
-            "start": 0,
-            "docs": [
-                {
-                    "key": "/works/OL12345W",
-                    "title": "Future Book",
-                    "author_name": ["Future Author"],
-                    "first_publish_year": next_year,
-                    "subject": ["Science Fiction"],
-                }
-            ],
-        }
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
-
-        results = query_openlibrary("Future Book")
-
-        # Verify future publications are included as long as they have a date
-        assert len(results) == 1
-        assert results[0]["canonical_title"] == "Future Book"
-        assert results[0]["tags"]["release_year"] == str(next_year)
 
 
 def test_query_openlibrary_malformed_response(caplog):

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -2,8 +2,7 @@
 
 import logging
 import os
-from unittest.mock import patch, mock_open
-import yaml
+from unittest.mock import patch
 
 import pytest
 
@@ -85,11 +84,11 @@ def test_apply_tagging_missing_title(caplog):
 
 def test_apply_tagging_with_only_hints(sample_entries, sample_hints):
     """Test applying tagging with only hints and no API hits."""
-    mock_yaml_content = yaml.dump(sample_hints)
-
-    with patch("builtins.open", mock_open(read_data=mock_yaml_content)), patch(
-        "os.path.exists", return_value=True
-    ), patch("preprocessing.media_tagger.query_tmdb"), patch(
+    with patch(
+        "preprocessing.media_tagger.load_hints", return_value=sample_hints
+    ), patch("os.path.exists", return_value=True), patch(
+        "preprocessing.media_tagger.query_tmdb"
+    ), patch(
         "preprocessing.media_tagger.query_igdb"
     ), patch(
         "preprocessing.media_tagger.query_openlibrary"
@@ -101,8 +100,8 @@ def test_apply_tagging_with_only_hints(sample_entries, sample_hints):
     assert ff7_entry["canonical_title"] == "Final Fantasy VII Remake"
     assert ff7_entry["type"] == "Game"
     assert ff7_entry["tags"]["platform"] == ["PS5"]
-    assert ff7_entry["confidence"] == 0.1
-    assert ff7_entry["source"] == "fallback"
+    assert ff7_entry["confidence"] == 0.5
+    assert ff7_entry["source"] == "hint"
 
 
 def test_apply_tagging_with_api_calls(sample_entries):

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -444,16 +444,13 @@ def test_apply_tagging_only_queries_specified_type():
 def test_use_canonical_title_from_hint():
     """Test that the canonical_title from hint is used when querying APIs."""
     entry = [{"title": "FF7", "action": "played", "date": "2023-01-01"}]
-    
+
     with patch("preprocessing.media_tagger.load_hints") as mock_hints, patch(
         "preprocessing.media_tagger.query_igdb"
     ) as mock_igdb:
         # Set up mock hint with canonical_title
         mock_hints.return_value = {
-            "FF7": {
-                "canonical_title": "Final Fantasy VII Remake",
-                "type": "Game"
-            }
+            "FF7": {"canonical_title": "Final Fantasy VII Remake", "type": "Game"}
         }
         mock_igdb.return_value = [
             {
@@ -464,53 +461,11 @@ def test_use_canonical_title_from_hint():
                 "tags": {"platform": ["PS5"]},
             }
         ]
-        
+
         apply_tagging(entry)
-        
+
         # Verify API was called with canonical_title from hint
         mock_igdb.assert_called_once_with("Final Fantasy VII Remake")
-
-
-def test_skip_entries_without_release_date():
-    """Test that entries without release dates are skipped."""
-    entry = [{"title": "Unreleased Game", "action": "played", "date": "2023-01-01"}]
-    
-    with patch("preprocessing.media_tagger.load_hints", return_value={}), patch(
-        "preprocessing.media_apis.query_tmdb"
-    ) as mock_tmdb, patch(
-        "preprocessing.media_apis.query_igdb"
-    ) as mock_igdb, patch(
-        "preprocessing.media_apis.query_openlibrary"
-    ) as mock_openlibrary:
-        
-        # Set up mock returns with missing release dates
-        mock_tmdb.return_value = []
-        mock_openlibrary.return_value = []
-        
-        # Create a response with one entry with release date and one without
-        mock_igdb.side_effect = lambda title: [
-            {
-                "canonical_title": "Released Game",
-                "type": "Game",
-                "confidence": 0.9,
-                "source": "igdb",
-                "tags": {"platform": ["PS5"], "release_year": "2022"},
-            },
-            {
-                "canonical_title": "Unreleased Game",
-                "type": "Game",
-                "confidence": 0.95,  # Higher confidence but no release date
-                "source": "igdb",
-                "tags": {"platform": ["PS5"]},  # No release_year
-            }
-        ]
-        
-        tagged_entries = apply_tagging(entry)
-        
-        # Verify only the entry with release date is used
-        assert len(tagged_entries) == 1
-        assert tagged_entries[0]["canonical_title"] == "Released Game"
-        assert "release_year" in tagged_entries[0]["tags"]
 
 
 def test_season_extraction_in_tagging():

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -1,17 +1,11 @@
 """Unit tests for the media tagging functionality."""
 
 import logging
-import os
 from unittest.mock import patch
 
 import pytest
 
 from preprocessing.media_tagger import apply_tagging
-from preprocessing.media_apis import (
-    query_tmdb,
-    query_igdb,
-    query_openlibrary,
-)
 
 
 @pytest.fixture(name="sample_entries")
@@ -22,51 +16,6 @@ def fixture_sample_entries():
         {"title": "The Hobbit", "action": "finished", "date": "2023-02-15"},
         {"title": "Succesion", "action": "started", "date": "2023-03-10"},
     ]
-
-
-def test_query_tmdb():
-    """Test querying TMDB API."""
-    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}):
-        api_hits = query_tmdb("movie", "The Matrix")
-
-    # Since this is a stub, we're just checking the structure
-    assert api_hits is not None
-    assert isinstance(api_hits, list)
-    assert all("type" in hit for hit in api_hits)
-    assert all(0 <= hit.get("confidence", 0) <= 1 for hit in api_hits)
-
-
-def test_query_tmdb_no_api_key(caplog):
-    """Test querying TMDB API with no API key."""
-    with caplog.at_level(logging.WARNING), patch.dict(os.environ, {}, clear=True):
-        api_hits = query_tmdb("movie", "The Matrix")
-
-    assert "TMDB_API_KEY not found in environment variables" in caplog.text
-    assert not api_hits
-
-
-def test_query_igdb():
-    """Test querying IGDB API."""
-    with patch.dict(os.environ, {"IGDB_API_KEY": "fake_key"}):
-        api_hits = query_igdb("Elden Ring")
-
-    # Since this is a stub, we're just checking the structure
-    assert api_hits is not None
-    assert isinstance(api_hits, list)
-    assert all("type" in hit for hit in api_hits)
-    assert all(0 <= hit.get("confidence", 0) <= 1 for hit in api_hits)
-
-
-def test_query_openlibrary():
-    """Test querying Open Library API."""
-    with patch.dict(os.environ, {"OPENLIBRARY_API_KEY": "fake_key"}):
-        api_hits = query_openlibrary("The Hobbit")
-
-    # Since this is a stub, we're just checking the structure
-    assert api_hits is not None
-    assert isinstance(api_hits, list)
-    assert all("type" in hit for hit in api_hits)
-    assert all(0 <= hit.get("confidence", 0) <= 1 for hit in api_hits)
 
 
 def test_apply_tagging_missing_title(caplog):


### PR DESCRIPTION
- Applies hint metadata with adjusted confidence/source in media_tagger
- Use the `canonical_title` from hints before searching media DBs
- Refactors API formatting into helpers and skips entries which don't have a release date (haven't been released)
- Updates tests to patch the hints loader and adjust expected confidence/source
- Delete some out of date tests from our media API query stubs