### PR TITLE
Batch media entries

### DIFF
--- a/preprocessing/media_tagger.py
+++ b/preprocessing/media_tagger.py
@@ -146,7 +146,6 @@ def _tag_entry(title: str, hints: Dict) -> Dict:
 
     Returns:
         A dictionary with the entry tagged with additional metadata: canonical_title, type, tags, confidence.
-        Returns None if the entry is not valid.
     """
     # Remove and re-add any season data.
     entry = {"title": title}
@@ -254,15 +253,19 @@ def _combine_similar_entries(tagged_entries: List[Dict]) -> List[Dict]:
             combined_entry["finished_dates"] = sorted(list(finished_dates))
 
             # Check for inconsistencies in tags or poster_path
+            combined_tagged = combined_entry.get("tagged", {})
             for next_entry in entries[1:]:
-                if next_entry.get("tags") != combined_entry.get("tags"):
+                next_tagged_entry = next_entry.get("tagged", {})
+                if next_tagged_entry.get("tags") != combined_tagged.get("tags"):
                     logger.warning(
                         "Inconsistent tags for entries with canonical_title '%s' and type '%s'. Discarding tags: %s",
                         key[0],
                         key[1],
-                        next_entry.get("tags"),
+                        next_tagged_entry.get("tags"),
                     )
-                if next_entry.get("poster_path") != combined_entry.get("poster_path"):
+                if next_tagged_entry.get("poster_path") != combined_tagged.get(
+                    "poster_path"
+                ):
                     logger.warning(
                         (
                             "Inconsistent poster_path for entries with canonical_title '%s' and type '%s'. Discarding "
@@ -270,9 +273,11 @@ def _combine_similar_entries(tagged_entries: List[Dict]) -> List[Dict]:
                         ),
                         key[0],
                         key[1],
-                        next_entry.get("poster_path"),
+                        next_tagged_entry.get("poster_path"),
                     )
-                if next_entry.get("confidence") != combined_entry.get("confidence"):
+                if next_tagged_entry.get("confidence") != combined_tagged.get(
+                    "confidence"
+                ):
                     logger.warning(
                         (
                             "Inconsistent confidence for entries with canonical_title '%s' and type '%s'. Discarding "
@@ -280,9 +285,9 @@ def _combine_similar_entries(tagged_entries: List[Dict]) -> List[Dict]:
                         ),
                         key[0],
                         key[1],
-                        next_entry.get("confidence"),
+                        next_tagged_entry.get("confidence"),
                     )
-                if next_entry.get("source") != combined_entry.get("source"):
+                if next_tagged_entry.get("source") != combined_tagged.get("source"):
                     logger.warning(
                         (
                             "Inconsistent source for entries with canonical_title '%s' and type '%s'. Discarding "
@@ -290,7 +295,7 @@ def _combine_similar_entries(tagged_entries: List[Dict]) -> List[Dict]:
                         ),
                         key[0],
                         key[1],
-                        next_entry.get("source"),
+                        next_tagged_entry.get("source"),
                     )
 
             final_entries.append(combined_entry)

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -13,6 +13,7 @@ from preprocessing.media_tagger import apply_tagging
 def reset_query_cache():
     """Reset query cache before each test to ensure consistent state."""
     media_tagger.QUERY_CACHE = {}
+    media_tagger.MEDIA_DB_API_CALL_COUNTS = {}
     yield
 
 

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -6,7 +6,7 @@ from unittest.mock import mock_open, patch
 
 from preprocessing.preprocess import (
     calculate_statistics,
-    load_weekly_records,
+    _load_weekly_records,
     process_and_save,
 )
 
@@ -27,7 +27,7 @@ def test_year_propagation():
 
     # Mock the open function to return our StringIO object
     with patch("builtins.open", mock_open(read_data=csv_content)):
-        records = load_weekly_records("dummy_path.csv")
+        records = _load_weekly_records("dummy_path.csv")
 
     # Check that years are correctly propagated
     assert records[0]["start_date"].startswith("2023-")  # Assuming current year is 2023
@@ -67,22 +67,26 @@ def test_process_and_save():
 
         mock_tag.return_value = [
             {
-                "title": "The Hobbit",
-                "canonical_title": "The Hobbit",
-                "type": "Book",
-                "action": "started",
-                "date": "2023-01-01",
-                "tags": {"genre": ["Fantasy"]},
-                "confidence": 0.9,
+                "tagged": {
+                    "canonical_title": "The Hobbit",
+                    "type": "Book",
+                    "tags": {"genre": ["Fantasy"]},
+                    "confidence": 0.9,
+                },
+                "original_titles": ["The Hobbit"],
+                "started_dates": ["2023-01-01"],
+                "finished_dates": [],
             },
             {
-                "title": "The Hobbit",
-                "canonical_title": "The Hobbit",
-                "type": "Book",
-                "action": "finished",
-                "date": "2023-02-01",
-                "tags": {"genre": ["Fantasy"]},
-                "confidence": 0.9,
+                "tagged": {
+                    "canonical_title": "The Hobbit",
+                    "type": "Book",
+                    "tags": {"genre": ["Fantasy"]},
+                    "confidence": 0.9,
+                },
+                "original_titles": ["The Hobbit"],
+                "started_dates": [],
+                "finished_dates": ["2023-02-01"],
             },
         ]
 
@@ -98,38 +102,30 @@ def test_process_and_save():
 
 def test_calculate_statistics():
     """Test the statistics calculation function."""
-    entries = [
+    tagged_entries = [
         {
-            "title": "Game A",
+            "canonical_title": "Game A",
             "type": "Game",
-            "action": "started",
-            "date": "2023-01-01",
             "confidence": 0.9,
         },
         {
-            "title": "Game A",
+            "canonical_title": "Game A",
             "type": "Game",
-            "action": "finished",
-            "date": "2023-02-01",
             "confidence": 0.9,
         },
         {
-            "title": "Book B",
+            "canonical_title": "Book B",
             "type": "Book",
-            "action": "started",
-            "date": "2023-03-01",
             "confidence": 0.4,
             "warnings": ["Low confidence match"],
         },
         {
-            "title": "Movie C",
+            "canonical_title": "Movie C",
             "type": "Movie",
-            "action": "finished",
-            "date": "2023-04-01",
             "confidence": 1.0,
         },
     ]
-
+    entries = [{"tagged": entry} for entry in tagged_entries]
     stats = calculate_statistics(entries)
 
     assert stats["total_entries"] == 4


### PR DESCRIPTION
To speed up preprocessing and to minimize load on the external APIs, aggregate the media entries as they appear across different weeks.  Then query the APIs for the media entry metadata.  The end result should be that each media entry includes it's metadata, it's different start dates, and different finish dates.

- Extract all media entries from weekly records
- Create a dictionary with titles as keys
- For each entry, add its action and date to the corresponding title's list
- This creates a mapping of {title -> [started_dates, finished_dates]}

Implement as
- Query APIs only once per unique title
- Apply metadata to all instances of that title
 - Combine the actions/dates into a single entry with multiple start/finish dates

Also keep an in-memory cache of queries to the DB
- Create a cache dictionary on (`search_title`, `media_type`)
- Before querying an API, check if the title is already in the cache
- If found, use the cached metadata
- If not, query the API and store the result in the cache

As a final stage, make a review pass over entries.  If any entries have identical `canonical_title` and `type` fields, then combine them.  Log a warning if fields like the `poster_path`, `tags`, etc deviate.

Refactors preprocessing to batch media entries by title, reducing redundant API calls, and updates the tagging pipeline to merge metadata and date ranges.

- Introduces _group_entries to collate start/finish dates per title before tagging
- Adds caching and API call counting in media_tagger, and a new _combine_similar_entries to merge duplicates
- Renames load_weekly_records to _load_weekly_records and adjusts process_and_save, calculate_statistics, and related tests for the new data shape