### PR TITLE
Reduced code duplication and improve test structure using setup fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,8 @@ def sample_hints():
                 "mood": ["Epic"],
             },
         },
-        "LOTR": {
-            "canonical_title": "The Lord of the Rings",
+        "The Hobbit": {
+            "canonical_title": "The Hobbit",
             "type": "Book",
             "tags": {
                 "genre": ["Fantasy"],

--- a/tests/test_media_apis.py
+++ b/tests/test_media_apis.py
@@ -256,7 +256,9 @@ def test_get_genre_map(mock_http_requests):
     assert genre_map == expected_genre_map
 
 
-def test_query_tmdb_movie_success(mock_api_responses, mock_tmdb_response, _mock_get_genre_map):
+def test_query_tmdb_movie_success(
+    mock_api_responses, mock_tmdb_response, _mock_get_genre_map
+):
     """Test successful TMDB movie query."""
     mock_tmdb_response(mock_api_responses["movie"])
 
@@ -274,7 +276,9 @@ def test_query_tmdb_movie_success(mock_api_responses, mock_tmdb_response, _mock_
     assert "poster_path" in results[0]
 
 
-def test_query_tmdb_tv_success(mock_api_responses, mock_tmdb_response, _mock_get_genre_map):
+def test_query_tmdb_tv_success(
+    mock_api_responses, mock_tmdb_response, _mock_get_genre_map
+):
     """Test successful TMDB TV query."""
     mock_tmdb_response(mock_api_responses["tv"])
 
@@ -324,7 +328,9 @@ def test_query_tmdb_api_error(mock_http_requests, caplog, _mock_get_genre_map):
         assert "Error querying TMDB API for movie: API Error" in caplog.text
 
 
-def test_query_tmdb_confidence_calculation(mock_api_responses, mock_tmdb_response, _mock_get_genre_map):
+def test_query_tmdb_confidence_calculation(
+    mock_api_responses, mock_tmdb_response, _mock_get_genre_map
+):
     """Test confidence calculation in TMDB query."""
     different_title = "Matrices and Their Many Uses in Mathematics"
     mock_tmdb_response(
@@ -359,7 +365,9 @@ def test_query_tmdb_confidence_calculation(mock_api_responses, mock_tmdb_respons
     assert similar_results["confidence"] > different_results["confidence"]
 
 
-def test_query_tmdb_limits_results(mock_api_responses, mock_tmdb_response, _mock_get_genre_map):
+def test_query_tmdb_limits_results(
+    mock_api_responses, mock_tmdb_response, _mock_get_genre_map
+):
     """Test that TMDB query limits results to top 5."""
     # Create mock response with more than 5 results
     mock_tmdb_response(mock_api_responses["movie"] * 10)
@@ -371,7 +379,9 @@ def test_query_tmdb_limits_results(mock_api_responses, mock_tmdb_response, _mock
     assert len(results) == 5
 
 
-def test_query_tmdb_handles_missing_fields(mock_api_responses, mock_tmdb_response, _mock_get_genre_map):
+def test_query_tmdb_handles_missing_fields(
+    mock_api_responses, mock_tmdb_response, _mock_get_genre_map
+):
     """Test that TMDB query handles missing fields gracefully."""
     # Create mock response with missing release_date
     unreleased_movies = [movie.copy() for movie in mock_api_responses["movie"]]
@@ -432,7 +442,9 @@ def test_get_igdb_token_api_error(caplog, mock_http_requests):
 
 def test_format_igdb_entry(mock_api_responses):
     """Test formatting an IGDB game entry."""
-    result = _format_igdb_entry("The Witcher 3: Wild Hunt", mock_api_responses["game"][0])
+    result = _format_igdb_entry(
+        "The Witcher 3: Wild Hunt", mock_api_responses["game"][0]
+    )
 
     assert result["canonical_title"] == "The Witcher 3: Wild Hunt"
     assert result["type"] == "Game"
@@ -563,7 +575,9 @@ def test_query_openlibrary_api_error(caplog, mock_http_requests):
         assert "Error querying Open Library API: API Error" in caplog.text
 
 
-def test_query_openlibrary_missing_fields(mock_api_responses, mock_openlibrary_response):
+def test_query_openlibrary_missing_fields(
+    mock_api_responses, mock_openlibrary_response
+):
     """Test OpenLibrary query with missing fields in response."""
     unreleased_books = [book.copy() for book in mock_api_responses["book"]]
     for book in unreleased_books:
@@ -587,11 +601,14 @@ def test_query_openlibrary_malformed_response(mock_http_requests):
     assert len(results) == 0
 
 
-def test_query_openlibrary_confidence_calculation(mock_api_responses, mock_openlibrary_response):
+def test_query_openlibrary_confidence_calculation(
+    mock_api_responses, mock_openlibrary_response
+):
     """Test confidence calculation in OpenLibrary query."""
     different_title = "The Fellowship of the Ring"
     mock_openlibrary_response(
-        mock_api_responses["book"] + [{"title": different_title, "first_publish_year": 1954}]
+        mock_api_responses["book"]
+        + [{"title": different_title, "first_publish_year": 1954}]
     )
 
     # Test with different search titles to test confidence calculation

--- a/tests/test_media_apis.py
+++ b/tests/test_media_apis.py
@@ -2,6 +2,8 @@
 
 import logging
 import os
+import datetime
+import time
 from unittest.mock import patch, MagicMock
 import pytest
 import requests
@@ -20,84 +22,82 @@ from preprocessing.media_apis import (
 
 
 @pytest.fixture(autouse=True)
-def reset_igdb_token():
-    """Reset IGDB token before each test to ensure consistent state."""
+def reset_api_state():
+    """Reset API state before each test to ensure consistent state."""
+    # Reset IGDB token
     media_apis.IGDB_TOKEN = None
+    # Reset genre map cache
+    GENRE_MAP_BY_MODE.clear()
     yield
 
 
-@pytest.fixture(name="mock_tmdb_movie_response")
-def fixture_mock_tmdb_movie_response():
-    """Mock response for TMDB movie search."""
+@pytest.fixture
+def mock_api_response():
+    """Create a mock API response."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    return mock_response
+
+
+@pytest.fixture
+def mock_tmdb_responses():
+    """Mock responses for TMDB API."""
     return {
-        "results": [
-            {
-                "id": 123,
-                "title": "The Matrix",
-                "release_date": "1999-03-31",
-                "popularity": 50.0,
-                "vote_average": 8.7,
-                "poster_path": "/path/to/poster.jpg",
-                "genre_ids": [28, 878],  # Action, Sci-Fi
-                "overview": "A computer hacker learns about the true nature of reality",
-            },
-            {
-                "id": 456,
-                "title": "The Matrix Reloaded",
-                "release_date": "2003-05-15",
-                "popularity": 40.0,
-                "vote_average": 7.2,
-                "poster_path": "/path/to/poster2.jpg",
-                "genre_ids": [28, 878],
-                "overview": "Neo and the rebels fight against the machines",
-            },
-        ]
+        "movie": {
+            "results": [
+                {
+                    "id": 123,
+                    "title": "The Matrix",
+                    "release_date": "1999-03-31",
+                    "popularity": 50.0,
+                    "vote_average": 8.7,
+                    "poster_path": "/path/to/poster.jpg",
+                    "genre_ids": [28, 878],  # Action, Sci-Fi
+                    "overview": "A computer hacker learns about the true nature of reality",
+                },
+                {
+                    "id": 456,
+                    "title": "The Matrix Reloaded",
+                    "release_date": "2003-05-15",
+                    "popularity": 40.0,
+                    "vote_average": 7.2,
+                    "poster_path": "/path/to/poster2.jpg",
+                    "genre_ids": [28, 878],
+                    "overview": "Neo and the rebels fight against the machines",
+                },
+            ]
+        },
+        "tv": {
+            "results": [
+                {
+                    "id": 789,
+                    "name": "Stranger Things",
+                    "first_air_date": "2016-07-15",
+                    "popularity": 80.0,
+                    "vote_average": 8.5,
+                    "poster_path": "/path/to/poster3.jpg",
+                    "genre_ids": [18, 9648, 10765],  # Drama, Mystery, Sci-Fi & Fantasy
+                    "overview": "When a young boy disappears, his mother and friends must confront terrifying forces",
+                }
+            ]
+        },
+        "genres": {
+            "genres": [
+                {"id": 28, "name": "Action"},
+                {"id": 18, "name": "Drama"},
+                {"id": 878, "name": "Science Fiction"},
+                {"id": 9648, "name": "Mystery"},
+                {"id": 10765, "name": "Sci-Fi & Fantasy"},
+            ]
+        }
     }
 
 
-@pytest.fixture(name="mock_tmdb_tv_response")
-def fixture_mock_tmdb_tv_response():
-    """Mock response for TMDB TV search."""
-    return {
-        "results": [
-            {
-                "id": 789,
-                "name": "Stranger Things",
-                "first_air_date": "2016-07-15",
-                "popularity": 80.0,
-                "vote_average": 8.5,
-                "poster_path": "/path/to/poster3.jpg",
-                "genre_ids": [18, 9648, 10765],  # Drama, Mystery, Sci-Fi & Fantasy
-                "overview": "When a young boy disappears, his mother and friends must confront terrifying forces",
-            }
-        ]
-    }
-
-
-@pytest.fixture(name="mock_genre_response")
-def fixture_mock_genre_response():
-    """Mock response for TMDB genre list."""
-    return {
-        "genres": [
-            {"id": 28, "name": "Action"},
-            {"id": 18, "name": "Drama"},
-            {"id": 878, "name": "Science Fiction"},
-            {"id": 9648, "name": "Mystery"},
-            {"id": 10765, "name": "Sci-Fi & Fantasy"},
-        ]
-    }
-
-
-def test_get_genre_map(mock_genre_response):
+def test_get_genre_map(mock_tmdb_responses, mock_api_response):
     """Test getting and caching the genre map."""
-    # Clear the cache
-    GENRE_MAP_BY_MODE.clear()
-
     with patch("requests.get") as mock_get:
-        mock_response = MagicMock()
-        mock_response.json.return_value = mock_genre_response
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        mock_api_response.json.return_value = mock_tmdb_responses["genres"]
+        mock_get.return_value = mock_api_response
 
         expected_genre_map = {
             28: "Action",
@@ -123,117 +123,125 @@ def test_get_genre_map(mock_genre_response):
         assert genre_map == expected_genre_map
 
 
-def test_query_tmdb_movie_success(mock_tmdb_movie_response, mock_genre_response):
+@pytest.fixture
+def setup_tmdb_mocks(mock_tmdb_responses, mock_api_response):
+    """Setup mocks for TMDB API tests."""
+    def _setup_mocks(mode):
+        with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), patch(
+            "requests.get"
+        ) as mock_get:
+            # Set up mock responses
+            def mock_response_side_effect(*args, **_):
+                mock_resp = mock_api_response
+                if f"search/{mode}" in args[0]:
+                    mock_resp.json.return_value = mock_tmdb_responses[mode]
+                elif f"genre/{mode}/list" in args[0]:
+                    mock_resp.json.return_value = mock_tmdb_responses["genres"]
+                return mock_resp
+
+            mock_get.side_effect = mock_response_side_effect
+            return mock_get
+    return _setup_mocks
+
+
+def test_query_tmdb_movie_success(setup_tmdb_mocks):
     """Test successful TMDB movie query."""
-    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), patch(
-        "requests.get"
-    ) as mock_get:
-        # Set up mock responses
-        def mock_response_side_effect(*args, **_):
-            mock_resp = MagicMock()
-            if "search/movie" in args[0]:
-                mock_resp.json.return_value = mock_tmdb_movie_response
-            elif "genre/movie/list" in args[0]:
-                mock_resp.json.return_value = mock_genre_response
-            mock_resp.raise_for_status.return_value = None
-            return mock_resp
+    mock_get = setup_tmdb_mocks("movie")
+    
+    # Call the function
+    results = query_tmdb("movie", "The Matrix")
 
-        mock_get.side_effect = mock_response_side_effect
-
-        # Call the function
-        results = query_tmdb("movie", "The Matrix")
-
-        # Verify results
-        assert len(results) == 2
-        assert results[0]["canonical_title"] == "The Matrix"
-        assert results[0]["type"] == "Movie"
-        assert results[0]["tags"]["genre"] == ["Action", "Science Fiction"]
-        assert results[0]["tags"]["release_year"] == "1999"
-        assert results[0]["confidence"] > 0.7  # High confidence for exact match
-        assert results[0]["source"] == "tmdb"
-        assert "poster_path" in results[0]
+    # Verify results
+    assert len(results) == 2
+    assert results[0]["canonical_title"] == "The Matrix"
+    assert results[0]["type"] == "Movie"
+    assert results[0]["tags"]["genre"] == ["Action", "Science Fiction"]
+    assert results[0]["tags"]["release_year"] == "1999"
+    assert results[0]["confidence"] > 0.7  # High confidence for exact match
+    assert results[0]["source"] == "tmdb"
+    assert "poster_path" in results[0]
 
 
-def test_query_tmdb_tv_success(mock_tmdb_tv_response, mock_genre_response):
+def test_query_tmdb_tv_success(setup_tmdb_mocks):
     """Test successful TMDB TV query."""
-    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), patch(
-        "requests.get"
-    ) as mock_get:
-        # Set up mock responses
-        def mock_response_side_effect(*args, **_):
-            mock_resp = MagicMock()
-            if "search/tv" in args[0]:
-                mock_resp.json.return_value = mock_tmdb_tv_response
-            elif "genre/tv/list" in args[0]:
-                mock_resp.json.return_value = mock_genre_response
-            mock_resp.raise_for_status.return_value = None
-            return mock_resp
+    mock_get = setup_tmdb_mocks("tv")
+    
+    # Call the function
+    results = query_tmdb("tv", "Stranger Things")
 
-        mock_get.side_effect = mock_response_side_effect
-
-        # Call the function
-        results = query_tmdb("tv", "Stranger Things")
-
-        # Verify results
-        assert len(results) == 1
-        assert results[0]["canonical_title"] == "Stranger Things"
-        assert results[0]["type"] == "TV Show"
-        assert "Drama" in results[0]["tags"]["genre"]
-        assert results[0]["tags"]["release_year"] == "2016"
-        assert results[0]["confidence"] > 0.7  # High confidence for exact match
-        assert results[0]["source"] == "tmdb"
+    # Verify results
+    assert len(results) == 1
+    assert results[0]["canonical_title"] == "Stranger Things"
+    assert results[0]["type"] == "TV Show"
+    assert "Drama" in results[0]["tags"]["genre"]
+    assert results[0]["tags"]["release_year"] == "2016"
+    assert results[0]["confidence"] > 0.7  # High confidence for exact match
+    assert results[0]["source"] == "tmdb"
 
 
-def test_query_tmdb_no_api_key(caplog):
+@pytest.fixture
+def setup_tmdb_error_tests():
+    """Setup for TMDB error test cases."""
+    def _setup(error_type, mock_response=None):
+        with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), patch(
+            "requests.get"
+        ) as mock_get:
+            if error_type == "no_api_key":
+                # Clear environment
+                os.environ.clear()
+            elif error_type == "empty_results":
+                # Set up mock for empty results
+                mock_response = MagicMock()
+                mock_response.json.return_value = {"results": []}
+                mock_response.raise_for_status.return_value = None
+                mock_get.return_value = mock_response
+            elif error_type == "api_error":
+                # Set up mock to raise an exception
+                mock_get.side_effect = requests.RequestException("API Error")
+            else:
+                # Custom mock response
+                mock_get.return_value = mock_response
+                
+            return mock_get
+    return _setup
+
+
+def test_query_tmdb_no_api_key(setup_tmdb_error_tests, caplog):
     """Test TMDB query with no API key."""
-    with patch.dict(os.environ, {}, clear=True), caplog.at_level(logging.WARNING):
+    setup_tmdb_error_tests("no_api_key")
+    
+    with caplog.at_level(logging.WARNING):
         results = query_tmdb("movie", "The Matrix")
-
+        
         assert len(results) == 0
         assert "TMDB_API_KEY not found in environment variables" in caplog.text
 
 
-def test_query_tmdb_empty_results():
+def test_query_tmdb_empty_results(setup_tmdb_error_tests):
     """Test TMDB query with empty results."""
-    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), patch(
-        "requests.get"
-    ) as mock_get:
-        # Set up mock responses
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"results": []}
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
-
-        # Call the function
-        results = query_tmdb("movie", "NonexistentMovie12345")
-
-        # Verify results
-        assert len(results) == 0
+    setup_tmdb_error_tests("empty_results")
+    
+    results = query_tmdb("movie", "NonexistentMovie12345")
+    
+    assert len(results) == 0
 
 
-def test_query_tmdb_api_error(caplog):
+def test_query_tmdb_api_error(setup_tmdb_error_tests, caplog):
     """Test TMDB query with API error."""
-    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), patch(
-        "requests.get"
-    ) as mock_get, caplog.at_level(logging.ERROR):
-        # Set up mock to raise an exception
-        mock_get.side_effect = requests.RequestException("API Error")
-
-        # Call the function
+    setup_tmdb_error_tests("api_error")
+    
+    with caplog.at_level(logging.ERROR):
         results = query_tmdb("movie", "The Matrix")
-
-        # Verify results
+        
         assert len(results) == 0
         assert "Error querying TMDB API for movie: API Error" in caplog.text
 
 
-def test_query_tmdb_confidence_calculation():
-    """Test confidence calculation in TMDB query."""
-    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), patch(
-        "requests.get"
-    ) as mock_get, patch("preprocessing.media_apis._get_genre_map", return_value={}):
-        # Create mock responses with varying similarity
-        exact_match = {
+@pytest.fixture
+def tmdb_confidence_test_data():
+    """Test data for TMDB confidence calculation tests."""
+    return {
+        "exact_match": {
             "results": [
                 {
                     "title": "Inception",
@@ -243,9 +251,8 @@ def test_query_tmdb_confidence_calculation():
                     "genre_ids": [],
                 }
             ]
-        }
-
-        similar_match = {
+        },
+        "similar_match": {
             "results": [
                 {
                     "title": "Inceptions",  # Slightly different
@@ -255,9 +262,8 @@ def test_query_tmdb_confidence_calculation():
                     "genre_ids": [],
                 }
             ]
-        }
-
-        different_match = {
+        },
+        "different_match": {
             "results": [
                 {
                     "title": "Completely Different Title",
@@ -267,37 +273,8 @@ def test_query_tmdb_confidence_calculation():
                     "genre_ids": [],
                 }
             ]
-        }
-
-        # Test exact match
-        mock_response = MagicMock()
-        mock_response.json.return_value = exact_match
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
-
-        exact_results = query_tmdb("movie", "Inception")
-
-        # Test similar match
-        mock_response.json.return_value = similar_match
-        similar_results = query_tmdb("movie", "Inception")
-
-        # Test different match
-        mock_response.json.return_value = different_match
-        different_results = query_tmdb("movie", "Inception")
-
-        # Verify confidence scores
-        assert exact_results[0]["confidence"] > similar_results[0]["confidence"]
-        assert similar_results[0]["confidence"] > different_results[0]["confidence"]
-
-
-def test_query_tmdb_limits_results():
-    """Test that TMDB query limits results to top 5."""
-    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), patch(
-        "requests.get"
-    ) as mock_get, patch("preprocessing.media_apis._get_genre_map", return_value={}):
-        # Create mock response with more than 5 results
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
+        },
+        "many_results": {
             "results": [
                 {
                     "title": f"Movie {i}",
@@ -308,25 +285,8 @@ def test_query_tmdb_limits_results():
                 }
                 for i in range(10)  # 10 results
             ]
-        }
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
-
-        # Call the function
-        results = query_tmdb("movie", "Movie")
-
-        # Verify results are limited to 5
-        assert len(results) == 5
-
-
-def test_query_tmdb_handles_missing_fields():
-    """Test that TMDB query handles missing fields gracefully."""
-    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), patch(
-        "requests.get"
-    ) as mock_get, patch("preprocessing.media_apis._get_genre_map", return_value={}):
-        # Create mock response with missing fields
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
+        },
+        "missing_fields": {
             "results": [
                 {
                     "title": "Movie With Missing Fields",
@@ -335,8 +295,56 @@ def test_query_tmdb_handles_missing_fields():
                 }
             ]
         }
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+    }
+
+
+def test_query_tmdb_confidence_calculation(tmdb_confidence_test_data, mock_api_response):
+    """Test confidence calculation in TMDB query."""
+    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), patch(
+        "requests.get"
+    ) as mock_get, patch("preprocessing.media_apis._get_genre_map", return_value={}):
+        # Test exact match
+        mock_api_response.json.return_value = tmdb_confidence_test_data["exact_match"]
+        mock_get.return_value = mock_api_response
+        exact_results = query_tmdb("movie", "Inception")
+
+        # Test similar match
+        mock_api_response.json.return_value = tmdb_confidence_test_data["similar_match"]
+        similar_results = query_tmdb("movie", "Inception")
+
+        # Test different match
+        mock_api_response.json.return_value = tmdb_confidence_test_data["different_match"]
+        different_results = query_tmdb("movie", "Inception")
+
+        # Verify confidence scores
+        assert exact_results[0]["confidence"] > similar_results[0]["confidence"]
+        assert similar_results[0]["confidence"] > different_results[0]["confidence"]
+
+
+def test_query_tmdb_limits_results(tmdb_confidence_test_data, mock_api_response):
+    """Test that TMDB query limits results to top 5."""
+    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), patch(
+        "requests.get"
+    ) as mock_get, patch("preprocessing.media_apis._get_genre_map", return_value={}):
+        # Create mock response with more than 5 results
+        mock_api_response.json.return_value = tmdb_confidence_test_data["many_results"]
+        mock_get.return_value = mock_api_response
+
+        # Call the function
+        results = query_tmdb("movie", "Movie")
+
+        # Verify results are limited to 5
+        assert len(results) == 5
+
+
+def test_query_tmdb_handles_missing_fields(tmdb_confidence_test_data, mock_api_response):
+    """Test that TMDB query handles missing fields gracefully."""
+    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), patch(
+        "requests.get"
+    ) as mock_get, patch("preprocessing.media_apis._get_genre_map", return_value={}):
+        # Create mock response with missing fields
+        mock_api_response.json.return_value = tmdb_confidence_test_data["missing_fields"]
+        mock_get.return_value = mock_api_response
 
         # Call the function
         results = query_tmdb("movie", "Movie")
@@ -345,142 +353,168 @@ def test_query_tmdb_handles_missing_fields():
         assert len(results) == 0
 
 
-@pytest.fixture(name="mock_igdb_auth_response")
-def fixture_mock_igdb_auth_response():
-    """Mock response for IGDB authentication."""
+@pytest.fixture
+def mock_igdb_responses():
+    """Mock responses for IGDB API."""
     return {
-        "access_token": "mock_access_token",
-        "expires_in": 14400,
-        "token_type": "bearer",
+        "auth": {
+            "access_token": "mock_access_token",
+            "expires_in": 14400,
+            "token_type": "bearer",
+        },
+        "games": [
+            {
+                "id": 1942,
+                "name": "The Witcher 3: Wild Hunt",
+                "first_release_date": 1431993600,  # May 19, 2015
+                "rating": 93.4,
+                "aggregated_rating": 91.2,
+                "cover": {
+                    "id": 89386,
+                    "url": "//images.igdb.com/igdb/image/upload/t_thumb/co1wyy.jpg",
+                },
+                "genres": [
+                    {"id": 12, "name": "Role-playing (RPG)"},
+                    {"id": 31, "name": "Adventure"},
+                ],
+                "platforms": [
+                    {"id": 6, "name": "PC"},
+                    {"id": 48, "name": "PlayStation 4"},
+                    {"id": 49, "name": "Xbox One"},
+                    {"id": 130, "name": "Nintendo Switch"},
+                ],
+            },
+            {
+                "id": 1943,
+                "name": "The Witcher 3: Wild Hunt - Hearts of Stone",
+                "first_release_date": 1444694400,  # October 13, 2015
+                "rating": 87.5,
+                "cover": {
+                    "id": 89387,
+                    "url": "//images.igdb.com/igdb/image/upload/t_thumb/co1wyz.jpg",
+                },
+                "genres": [
+                    {"id": 12, "name": "Role-playing (RPG)"},
+                    {"id": 31, "name": "Adventure"},
+                ],
+                "platforms": [
+                    {"id": 6, "name": "PC"},
+                    {"id": 48, "name": "PlayStation 4"},
+                    {"id": 49, "name": "Xbox One"},
+                ],
+            },
+        ],
+        "empty": []
     }
 
 
-@pytest.fixture(name="mock_igdb_games_response")
-def fixture_mock_igdb_games_response():
-    """Mock response for IGDB games search."""
-    return [
-        {
-            "id": 1942,
-            "name": "The Witcher 3: Wild Hunt",
-            "first_release_date": 1431993600,  # May 19, 2015
-            "rating": 93.4,
-            "aggregated_rating": 91.2,
-            "cover": {
-                "id": 89386,
-                "url": "//images.igdb.com/igdb/image/upload/t_thumb/co1wyy.jpg",
-            },
-            "genres": [
-                {"id": 12, "name": "Role-playing (RPG)"},
-                {"id": 31, "name": "Adventure"},
-            ],
-            "platforms": [
-                {"id": 6, "name": "PC"},
-                {"id": 48, "name": "PlayStation 4"},
-                {"id": 49, "name": "Xbox One"},
-                {"id": 130, "name": "Nintendo Switch"},
-            ],
-        },
-        {
-            "id": 1943,
-            "name": "The Witcher 3: Wild Hunt - Hearts of Stone",
-            "first_release_date": 1444694400,  # October 13, 2015
-            "rating": 87.5,
-            "cover": {
-                "id": 89387,
-                "url": "//images.igdb.com/igdb/image/upload/t_thumb/co1wyz.jpg",
-            },
-            "genres": [
-                {"id": 12, "name": "Role-playing (RPG)"},
-                {"id": 31, "name": "Adventure"},
-            ],
-            "platforms": [
-                {"id": 6, "name": "PC"},
-                {"id": 48, "name": "PlayStation 4"},
-                {"id": 49, "name": "Xbox One"},
-            ],
-        },
-    ]
+@pytest.fixture
+def setup_igdb_mocks(mock_igdb_responses, mock_api_response):
+    """Setup mocks for IGDB API tests."""
+    def _setup_mocks(response_type="games", error_type=None):
+        with patch.dict(
+            os.environ,
+            {
+                "IGDB_CLIENT_ID": "fake_client_id",
+                "IGDB_CLIENT_SECRET": "fake_client_secret",
+            }
+        ):
+            if error_type == "missing_credentials":
+                os.environ.clear()
+                return None
+                
+            if error_type == "api_error":
+                with patch("requests.post") as mock_post:
+                    mock_post.side_effect = requests.RequestException("API Error")
+                    return mock_post
+            
+            with patch("requests.post") as mock_post:
+                mock_api_response.json.return_value = mock_igdb_responses[response_type]
+                mock_post.return_value = mock_api_response
+                return mock_post
+    return _setup_mocks
 
 
 def test_calculate_title_similarity():
     """Test the title similarity calculation function."""
-    # Identical titles
-    assert _calculate_title_similarity("The Witcher 3", "The Witcher 3") == 1.0
-
-    # Similar titles
-    similarity = _calculate_title_similarity("The Witcher 3", "The Witcher III")
-    assert 0.7 < similarity < 1.0
-
-    # Different titles
-    similarity = _calculate_title_similarity("The Witcher 3", "Cyberpunk 2077")
-    assert similarity < 0.5
-
-    # Empty titles
-    assert _calculate_title_similarity("", "") == 1.0
-    assert _calculate_title_similarity("Title", "") < 1.0
+    test_cases = [
+        # (title1, title2, expected_range)
+        ("The Witcher 3", "The Witcher 3", (1.0, 1.0)),  # Identical
+        ("The Witcher 3", "The Witcher III", (0.7, 1.0)),  # Similar
+        ("The Witcher 3", "Cyberpunk 2077", (0.0, 0.5)),  # Different
+        ("", "", (1.0, 1.0)),  # Empty
+        ("Title", "", (0.0, 0.2)),  # One empty
+    ]
+    
+    for title1, title2, (min_val, max_val) in test_cases:
+        similarity = _calculate_title_similarity(title1, title2)
+        assert min_val <= similarity <= max_val, f"Failed for {title1} vs {title2}"
 
 
-def test_get_igdb_token_success(mock_igdb_auth_response):
+def test_get_igdb_token_success(setup_igdb_mocks):
     """Test successful IGDB token retrieval."""
-    with patch.dict(
-        os.environ,
-        {
-            "IGDB_CLIENT_ID": "fake_client_id",
-            "IGDB_CLIENT_SECRET": "fake_client_secret",
-        },
-    ), patch("requests.post") as mock_post:
-        mock_response = MagicMock()
-        mock_response.json.return_value = mock_igdb_auth_response
-        mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
-
-        token = _get_igdb_token()
-
-        assert token == "mock_access_token"
-        mock_post.assert_called_once()
-        assert "'client_id': 'fake_client_id'" in str(mock_post.call_args)
-        assert "'client_secret': 'fake_client_secret'" in str(mock_post.call_args)
+    mock_post = setup_igdb_mocks("auth")
+    
+    token = _get_igdb_token()
+    
+    assert token == "mock_access_token"
+    mock_post.assert_called_once()
+    assert "'client_id': 'fake_client_id'" in str(mock_post.call_args)
+    assert "'client_secret': 'fake_client_secret'" in str(mock_post.call_args)
 
 
-def test_get_igdb_token_missing_credentials(caplog):
+def test_get_igdb_token_missing_credentials(setup_igdb_mocks, caplog):
     """Test IGDB token retrieval with missing credentials."""
-    with patch.dict(os.environ, {}, clear=True), caplog.at_level(logging.WARNING):
+    setup_igdb_mocks(error_type="missing_credentials")
+    
+    with caplog.at_level(logging.WARNING):
         token = _get_igdb_token()
-
+        
         assert token is None
         assert "IGDB_CLIENT_ID or IGDB_CLIENT_SECRET not found" in caplog.text
 
 
-def test_get_igdb_token_api_error(caplog):
+def test_get_igdb_token_api_error(setup_igdb_mocks, caplog):
     """Test IGDB token retrieval with API error."""
-    with patch.dict(
-        os.environ,
-        {
-            "IGDB_CLIENT_ID": "fake_client_id",
-            "IGDB_CLIENT_SECRET": "fake_client_secret",
-        },
-    ), patch("requests.post") as mock_post, caplog.at_level(logging.ERROR):
-        mock_post.side_effect = requests.RequestException("API Error")
-
+    mock_post = setup_igdb_mocks(error_type="api_error")
+    
+    with caplog.at_level(logging.ERROR):
         token = _get_igdb_token()
-
+        
         assert token is None
         assert mock_post.called
 
 
-def test_format_igdb_entry():
-    """Test formatting an IGDB game entry."""
-    game = {
-        "name": "The Witcher 3",
-        "first_release_date": 1431993600,  # May 19, 2015
-        "rating": 93.4,
-        "aggregated_rating": 91.2,
-        "cover": {"url": "//images.igdb.com/igdb/image/upload/t_thumb/co1wyy.jpg"},
-        "genres": [{"name": "Role-playing (RPG)"}, {"name": "Adventure"}],
-        "platforms": [{"name": "PC"}, {"name": "PlayStation 4"}],
+@pytest.fixture
+def igdb_test_games():
+    """Test game data for IGDB formatting tests."""
+    return {
+        "complete": {
+            "name": "The Witcher 3",
+            "first_release_date": 1431993600,  # May 19, 2015
+            "rating": 93.4,
+            "aggregated_rating": 91.2,
+            "cover": {"url": "//images.igdb.com/igdb/image/upload/t_thumb/co1wyy.jpg"},
+            "genres": [{"name": "Role-playing (RPG)"}, {"name": "Adventure"}],
+            "platforms": [{"name": "PC"}, {"name": "PlayStation 4"}],
+        },
+        "minimal": {
+            "name": "Minimal Game",
+            # Missing most fields
+        },
+        "partial": {
+            "name": "Partial Game",
+            "first_release_date": 1577836800,  # January 1, 2020
+            "genres": [],  # Empty list
+            "platforms": [{"name": "PC"}],
+            "cover": {"url": "thumb/image.jpg"},  # Malformed URL
+        }
     }
 
-    result = _format_igdb_entry("The Witcher 3", game)
+
+def test_format_igdb_entry(igdb_test_games):
+    """Test formatting an IGDB game entry."""
+    result = _format_igdb_entry("The Witcher 3", igdb_test_games["complete"])
 
     assert result["canonical_title"] == "The Witcher 3"
     assert result["type"] == "Game"
@@ -493,59 +527,31 @@ def test_format_igdb_entry():
     assert "720p" in result["poster_path"]  # Should upgrade image quality
 
 
-def test_format_igdb_entry_missing_fields():
+def test_format_igdb_entry_missing_fields(igdb_test_games):
     """Test formatting an IGDB game entry with missing fields."""
-    game = {
-        "name": "Minimal Game",
-        # Missing most fields
-    }
-
-    result = _format_igdb_entry("Minimal Game", game)
+    result = _format_igdb_entry("Minimal Game", igdb_test_games["minimal"])
 
     # Results without a first_release_date should not be included
     assert result is None
 
 
-def test_format_igdb_entry_partial_fields():
+def test_format_igdb_entry_partial_fields(igdb_test_games):
     """Test formatting an IGDB game entry with partial fields."""
-    game = {
-        "name": "Partial Game",
-        "first_release_date": 1577836800,  # January 1, 2020
-        "genres": [],  # Empty list
-        "platforms": [{"name": "PC"}],
-        "cover": {"url": "thumb/image.jpg"},  # Malformed URL
-    }
-
-    result = _format_igdb_entry("Partial Game", game)
+    result = _format_igdb_entry("Partial Game", igdb_test_games["partial"])
 
     assert result["canonical_title"] == "Partial Game"
     assert result["type"] == "Game"
     assert result["tags"]["genre"] == []
     assert result["tags"]["platform"] == ["PC"]
     assert result["tags"]["release_year"] == "2020"
-    assert (
-        result["poster_path"] == "720p/image.jpg"
-    )  # If not starting with //, it should not add https:
+    assert result["poster_path"] == "720p/image.jpg"  # Should replace thumb with 720p
 
 
-def test_query_igdb_success(mock_igdb_games_response):
+def test_query_igdb_success(setup_igdb_mocks):
     """Test successful IGDB query."""
-    with patch.dict(
-        os.environ,
-        {
-            "IGDB_CLIENT_ID": "fake_client_id",
-            "IGDB_CLIENT_SECRET": "fake_client_secret",
-        },
-    ), patch(
-        "preprocessing.media_apis._get_igdb_token", return_value="mock_token"
-    ), patch(
-        "requests.post"
-    ) as mock_post:
-        mock_response = MagicMock()
-        mock_response.json.return_value = mock_igdb_games_response
-        mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
-
+    mock_post = setup_igdb_mocks("games")
+    
+    with patch("preprocessing.media_apis._get_igdb_token", return_value="mock_token"):
         results = query_igdb("The Witcher 3")
 
         assert len(results) == 2
@@ -566,122 +572,64 @@ def test_query_igdb_success(mock_igdb_games_response):
 
 def test_query_igdb_no_token():
     """Test IGDB query with no token."""
-    with patch("preprocessing.media_apis._get_igdb_token", return_value=""):
+    with patch("preprocessing.media_apis._get_igdb_token", return_value=None):
         results = query_igdb("The Witcher 3")
-
         assert len(results) == 0
 
 
-def test_query_igdb_api_error(caplog):
+def test_query_igdb_api_error(setup_igdb_mocks, caplog):
     """Test IGDB query with API error."""
-    with patch(
-        "preprocessing.media_apis._get_igdb_token", return_value="mock_token"
-    ), patch("requests.post") as mock_post, caplog.at_level(logging.ERROR):
-        mock_post.side_effect = requests.RequestException("API Error")
-
+    mock_post = setup_igdb_mocks(error_type="api_error")
+    
+    with patch("preprocessing.media_apis._get_igdb_token", return_value="mock_token"), caplog.at_level(logging.ERROR):
         results = query_igdb("The Witcher 3")
-
+        
         assert len(results) == 0
         assert "Error querying IGDB API: API Error" in caplog.text
 
 
-def test_query_igdb_empty_results():
+def test_query_igdb_empty_results(setup_igdb_mocks):
     """Test IGDB query with empty results."""
-    with patch(
-        "preprocessing.media_apis._get_igdb_token", return_value="mock_token"
-    ), patch("requests.post") as mock_post:
-        mock_response = MagicMock()
-        mock_response.json.return_value = []  # Empty results
-        mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
-
+    mock_post = setup_igdb_mocks("empty")
+    
+    with patch("preprocessing.media_apis._get_igdb_token", return_value="mock_token"):
         results = query_igdb("NonexistentGame12345")
-
+        
         assert len(results) == 0
 
 
-@pytest.fixture(name="mock_openlibrary_response")
-def fixture_mock_openlibrary_response():
-    """Mock response for OpenLibrary search."""
+@pytest.fixture
+def mock_openlibrary_responses():
+    """Mock responses for OpenLibrary API."""
     return {
-        "numFound": 2,
-        "start": 0,
-        "docs": [
-            {
-                "key": "/works/OL45883W",
-                "title": "The Hobbit",
-                "author_name": ["J.R.R. Tolkien"],
-                "first_publish_year": 1937,
-                "subject": ["Fantasy", "Fiction", "Adventure"],
-                "cover_i": 12345,
-            },
-            {
-                "key": "/works/OL12345W",
-                "title": "The Hobbit: An Unexpected Journey",
-                "author_name": ["J.R.R. Tolkien", "Peter Jackson"],
-                "first_publish_year": 2012,
-                "subject": ["Fantasy", "Film Adaptation"],
-                "cover_i": 67890,
-            },
-        ],
-    }
-
-
-def test_query_openlibrary_success(mock_openlibrary_response):
-    """Test successful OpenLibrary query."""
-    with patch("requests.get") as mock_get:
-        mock_response = MagicMock()
-        mock_response.json.return_value = mock_openlibrary_response
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
-
-        results = query_openlibrary("The Hobbit")
-
-        # Verify results
-        assert len(results) == 2
-        assert results[0]["canonical_title"] == "The Hobbit"
-        assert results[0]["type"] == "Book"
-        assert "Fantasy" in results[0]["tags"]["genre"]
-        assert "J.R.R. Tolkien" in results[0]["tags"]["author"]
-        assert results[0]["tags"]["release_year"] == "1937"
-        assert results[0]["confidence"] > 0.7  # High confidence for exact match
-        assert results[0]["source"] == "openlibrary"
-        assert "covers.openlibrary.org" in results[0]["poster_path"]
-
-        # Verify API call
-        mock_get.assert_called_once()
-        assert mock_get.call_args.kwargs["params"]["title"] == "The Hobbit"
-
-
-def test_query_openlibrary_empty_results():
-    """Test OpenLibrary query with empty results."""
-    with patch("requests.get") as mock_get:
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"numFound": 0, "start": 0, "docs": []}
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
-
-        results = query_openlibrary("NonexistentBook12345")
-
-        assert len(results) == 0
-
-
-def test_query_openlibrary_api_error(caplog):
-    """Test OpenLibrary query with API error."""
-    with patch("requests.get") as mock_get, caplog.at_level(logging.ERROR):
-        mock_get.side_effect = requests.RequestException("API Error")
-
-        results = query_openlibrary("The Hobbit")
-
-        assert len(results) == 0
-        assert "Error querying Open Library API: API Error" in caplog.text
-
-
-def test_query_openlibrary_missing_fields():
-    """Test OpenLibrary query with missing fields in response."""
-    with patch("requests.get") as mock_get:
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
+        "success": {
+            "numFound": 2,
+            "start": 0,
+            "docs": [
+                {
+                    "key": "/works/OL45883W",
+                    "title": "The Hobbit",
+                    "author_name": ["J.R.R. Tolkien"],
+                    "first_publish_year": 1937,
+                    "subject": ["Fantasy", "Fiction", "Adventure"],
+                    "cover_i": 12345,
+                },
+                {
+                    "key": "/works/OL12345W",
+                    "title": "The Hobbit: An Unexpected Journey",
+                    "author_name": ["J.R.R. Tolkien", "Peter Jackson"],
+                    "first_publish_year": 2012,
+                    "subject": ["Fantasy", "Film Adaptation"],
+                    "cover_i": 67890,
+                },
+            ],
+        },
+        "empty": {
+            "numFound": 0, 
+            "start": 0, 
+            "docs": []
+        },
+        "missing_fields": {
             "numFound": 1,
             "start": 0,
             "docs": [
@@ -691,36 +639,11 @@ def test_query_openlibrary_missing_fields():
                     # Missing: author_name, first_publish_year, subject, cover_i
                 }
             ],
-        }
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
-
-        results = query_openlibrary("Book")
-
-        # Verify results handle missing a first_publish_year are omitted
-        assert len(results) == 0
-
-
-def test_query_openlibrary_malformed_response(caplog):
-    """Test OpenLibrary query with malformed response."""
-    with patch("requests.get") as mock_get, caplog.at_level(logging.ERROR):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "malformed": "response"
-        }  # Missing 'docs' key
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
-
-        results = query_openlibrary("The Hobbit")
-
-        assert len(results) == 0
-
-
-def test_query_openlibrary_confidence_calculation():
-    """Test confidence calculation in OpenLibrary query."""
-    with patch("requests.get") as mock_get:
-        # Create mock responses with varying similarity
-        response = {
+        },
+        "malformed": {
+            "malformed": "response"  # Missing 'docs' key
+        },
+        "confidence_test": {
             "numFound": 1,
             "docs": [
                 {
@@ -729,21 +652,94 @@ def test_query_openlibrary_confidence_calculation():
                 }
             ],
         }
+    }
 
-        # Test exact match
-        mock_response = MagicMock()
-        mock_response.json.return_value = response
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
 
-        exact_results = query_openlibrary("Lord of the Rings")
+@pytest.fixture
+def setup_openlibrary_mocks(mock_openlibrary_responses, mock_api_response):
+    """Setup mocks for OpenLibrary API tests."""
+    def _setup_mocks(response_type="success", error_type=None):
+        with patch("requests.get") as mock_get:
+            if error_type == "api_error":
+                mock_get.side_effect = requests.RequestException("API Error")
+                return mock_get
+                
+            mock_api_response.json.return_value = mock_openlibrary_responses[response_type]
+            mock_get.return_value = mock_api_response
+            return mock_get
+    return _setup_mocks
 
-        # Test similar match
-        similar_results = query_openlibrary("The Lord of the Rings")
 
-        # Test different match
-        different_results = query_openlibrary("Completely Different Title")
+def test_query_openlibrary_success(setup_openlibrary_mocks):
+    """Test successful OpenLibrary query."""
+    mock_get = setup_openlibrary_mocks("success")
+    
+    results = query_openlibrary("The Hobbit")
+    
+    # Verify results
+    assert len(results) == 2
+    assert results[0]["canonical_title"] == "The Hobbit"
+    assert results[0]["type"] == "Book"
+    assert "Fantasy" in results[0]["tags"]["genre"]
+    assert "J.R.R. Tolkien" in results[0]["tags"]["author"]
+    assert results[0]["tags"]["release_year"] == "1937"
+    assert results[0]["confidence"] > 0.7  # High confidence for exact match
+    assert results[0]["source"] == "openlibrary"
+    assert "covers.openlibrary.org" in results[0]["poster_path"]
+    
+    # Verify API call
+    mock_get.assert_called_once()
+    assert mock_get.call_args.kwargs["params"]["title"] == "The Hobbit"
 
-        # Verify confidence scores
-        assert exact_results[0]["confidence"] > similar_results[0]["confidence"]
-        assert similar_results[0]["confidence"] > different_results[0]["confidence"]
+
+def test_query_openlibrary_empty_results(setup_openlibrary_mocks):
+    """Test OpenLibrary query with empty results."""
+    setup_openlibrary_mocks("empty")
+    
+    results = query_openlibrary("NonexistentBook12345")
+    
+    assert len(results) == 0
+
+
+def test_query_openlibrary_api_error(setup_openlibrary_mocks, caplog):
+    """Test OpenLibrary query with API error."""
+    setup_openlibrary_mocks(error_type="api_error")
+    
+    with caplog.at_level(logging.ERROR):
+        results = query_openlibrary("The Hobbit")
+        
+        assert len(results) == 0
+        assert "Error querying Open Library API: API Error" in caplog.text
+
+
+def test_query_openlibrary_missing_fields(setup_openlibrary_mocks):
+    """Test OpenLibrary query with missing fields in response."""
+    setup_openlibrary_mocks("missing_fields")
+    
+    results = query_openlibrary("Book")
+    
+    # Verify results handle missing a first_publish_year are omitted
+    assert len(results) == 0
+
+
+def test_query_openlibrary_malformed_response(setup_openlibrary_mocks):
+    """Test OpenLibrary query with malformed response."""
+    setup_openlibrary_mocks("malformed")
+    
+    results = query_openlibrary("The Hobbit")
+    
+    assert len(results) == 0
+
+
+def test_query_openlibrary_confidence_calculation(setup_openlibrary_mocks):
+    """Test confidence calculation in OpenLibrary query."""
+    mock_get = setup_openlibrary_mocks("confidence_test")
+    
+    # Test with different search titles to test confidence calculation
+    exact_results = query_openlibrary("Lord of the Rings")
+    similar_results = query_openlibrary("The Lord of the Rings")
+    different_results = query_openlibrary("Completely Different Title")
+    
+    # Verify confidence scores
+    assert exact_results[0]["confidence"] > similar_results[0]["confidence"]
+    assert similar_results[0]["confidence"] > different_results[0]["confidence"]

--- a/tests/test_media_apis.py
+++ b/tests/test_media_apis.py
@@ -2,8 +2,6 @@
 
 import logging
 import os
-import datetime
-import time
 from unittest.mock import patch, MagicMock
 import pytest
 import requests
@@ -21,6 +19,18 @@ from preprocessing.media_apis import (
 )
 
 
+GENRE_MAPPING = [
+    {"id": 28, "name": "Action"},
+    {"id": 18, "name": "Drama"},
+    {"id": 878, "name": "Science Fiction"},
+    {"id": 9648, "name": "Mystery"},
+    {"id": 10765, "name": "Sci-Fi & Fantasy"},
+]
+GENRE_RESPONSE = {
+    "genres": GENRE_MAPPING,
+}
+
+
 @pytest.fixture(autouse=True)
 def mock_http_requests():
     """
@@ -33,14 +43,26 @@ def mock_http_requests():
         mock_post.side_effect = RuntimeError("Unmocked HTTP POST request attempted")
         yield mock_get, mock_post
 
+
 @pytest.fixture(autouse=True)
 def reset_api_state():
-    """Reset API state before each test to ensure consistent state."""
-    # Reset IGDB token
+    """Reset API state (IGDB token & genre map cache) before each test to ensure consistent state."""
     media_apis.IGDB_TOKEN = None
-    # Reset genre map cache
     GENRE_MAP_BY_MODE.clear()
-    yield
+
+
+@pytest.fixture(autouse=True)
+def mock_env_variables():
+    """Set up environment variables for API keys."""
+    with patch.dict(
+        os.environ,
+        {
+            "IGDB_CLIENT_ID": "fake_client_id",
+            "IGDB_CLIENT_SECRET": "fake_client_secret",
+            "TMDB_API_KEY": "fake_key",
+        },
+    ):
+        yield
 
 
 @pytest.fixture
@@ -93,164 +115,60 @@ def mock_tmdb_responses():
                 }
             ]
         },
-        "genres": {
-            "genres": [
-                {"id": 28, "name": "Action"},
-                {"id": 18, "name": "Drama"},
-                {"id": 878, "name": "Science Fiction"},
-                {"id": 9648, "name": "Mystery"},
-                {"id": 10765, "name": "Sci-Fi & Fantasy"},
-            ]
-        }
+        "genres": GENRE_RESPONSE,
     }
-
-
-def test_get_genre_map(mock_tmdb_responses, mock_api_response, mock_http_requests):
-    """Test getting and caching the genre map."""
-    mock_get, _ = mock_http_requests
-    mock_api_response.json.return_value = mock_tmdb_responses["genres"]
-    mock_get.return_value = mock_api_response
-    mock_get.side_effect = None  # Override the default side_effect
-
-    expected_genre_map = {
-        28: "Action",
-        18: "Drama",
-        878: "Science Fiction",
-        9648: "Mystery",
-        10765: "Sci-Fi & Fantasy",
-    }
-
-    # First call should make the API request
-    genre_map = _get_genre_map("movie")
-    assert mock_get.call_count == 1
-    assert genre_map == expected_genre_map
-
-    # Second call should use the cached value
-    genre_map = _get_genre_map("movie")
-    assert mock_get.call_count == 1
-    assert genre_map == expected_genre_map
-
-    # Different mode should make a new request
-    genre_map = _get_genre_map("tv")
-    assert mock_get.call_count == 2
-    assert genre_map == expected_genre_map
-
-
-@pytest.fixture
-def setup_tmdb_mocks(mock_tmdb_responses, mock_api_response, mock_http_requests):
-    """Setup mocks for TMDB API tests."""
-    def _setup_mocks(mode):
-        mock_get, _ = mock_http_requests
-        
-        # Set up environment variables
-        with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}):
-            # Set up mock responses
-            def mock_response_side_effect(*args, **_):
-                mock_resp = mock_api_response
-                if f"search/{mode}" in args[0]:
-                    mock_resp.json.return_value = mock_tmdb_responses[mode]
-                elif f"genre/{mode}/list" in args[0]:
-                    mock_resp.json.return_value = mock_tmdb_responses["genres"]
-                return mock_resp
-
-            mock_get.side_effect = mock_response_side_effect
-            return mock_get
-    return _setup_mocks
-
-
-def test_query_tmdb_movie_success(setup_tmdb_mocks):
-    """Test successful TMDB movie query."""
-    mock_get = setup_tmdb_mocks("movie")
-    
-    # Call the function
-    results = query_tmdb("movie", "The Matrix")
-
-    # Verify results
-    assert len(results) == 2
-    assert results[0]["canonical_title"] == "The Matrix"
-    assert results[0]["type"] == "Movie"
-    assert results[0]["tags"]["genre"] == ["Action", "Science Fiction"]
-    assert results[0]["tags"]["release_year"] == "1999"
-    assert results[0]["confidence"] > 0.7  # High confidence for exact match
-    assert results[0]["source"] == "tmdb"
-    assert "poster_path" in results[0]
-
-
-def test_query_tmdb_tv_success(setup_tmdb_mocks):
-    """Test successful TMDB TV query."""
-    mock_get = setup_tmdb_mocks("tv")
-    
-    # Call the function
-    results = query_tmdb("tv", "Stranger Things")
-
-    # Verify results
-    assert len(results) == 1
-    assert results[0]["canonical_title"] == "Stranger Things"
-    assert results[0]["type"] == "TV Show"
-    assert "Drama" in results[0]["tags"]["genre"]
-    assert results[0]["tags"]["release_year"] == "2016"
-    assert results[0]["confidence"] > 0.7  # High confidence for exact match
-    assert results[0]["source"] == "tmdb"
 
 
 @pytest.fixture
 def setup_tmdb_error_tests(mock_http_requests):
     """Setup for TMDB error test cases."""
+
     def _setup(error_type, mock_response=None):
         mock_get, _ = mock_http_requests
-        
-        with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}):
-            if error_type == "no_api_key":
-                # Clear environment
-                os.environ.clear()
-            elif error_type == "empty_results":
-                # Set up mock for empty results
-                mock_response = MagicMock()
-                mock_response.json.return_value = {"results": []}
-                mock_response.raise_for_status.return_value = None
-                mock_get.return_value = mock_response
-                mock_get.side_effect = None
-            elif error_type == "api_error":
-                # Set up mock to raise an exception
-                mock_get.side_effect = requests.RequestException("API Error")
-            else:
-                # Custom mock response
-                mock_get.return_value = mock_response
-                mock_get.side_effect = None
-                
-            return mock_get
+
+        if error_type == "no_api_key":
+            # Clear environment
+            os.environ.clear()
+        elif error_type == "empty_results":
+            # Set up mock for empty results
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"results": []}
+            mock_response.raise_for_status.return_value = None
+            mock_get.return_value = mock_response
+            mock_get.side_effect = None
+        elif error_type == "api_error":
+            # Set up mock to raise an exception
+            mock_get.side_effect = requests.RequestException("API Error")
+        else:
+            # Custom mock response
+            mock_get.return_value = mock_response
+            mock_get.side_effect = None
+
+        return mock_get
+
     return _setup
 
 
-def test_query_tmdb_no_api_key(setup_tmdb_error_tests, caplog):
-    """Test TMDB query with no API key."""
-    setup_tmdb_error_tests("no_api_key")
-    
-    with caplog.at_level(logging.WARNING):
-        results = query_tmdb("movie", "The Matrix")
-        
-        assert len(results) == 0
-        assert "TMDB_API_KEY not found in environment variables" in caplog.text
+@pytest.fixture
+def setup_tmdb_mocks(mock_tmdb_responses, mock_api_response, mock_http_requests):
+    """Setup mocks for TMDB API tests."""
 
+    def _setup_mocks(mode):
+        mock_get, _ = mock_http_requests
 
-def test_query_tmdb_empty_results(setup_tmdb_error_tests):
-    """Test TMDB query with empty results."""
-    setup_tmdb_error_tests("empty_results")
-    
-    results = query_tmdb("movie", "NonexistentMovie12345")
-    
-    assert len(results) == 0
+        # Set up mock responses
+        def mock_response_side_effect(*args, **_):
+            mock_resp = mock_api_response
+            if f"search/{mode}" in args[0]:
+                mock_resp.json.return_value = mock_tmdb_responses[mode]
+            elif f"genre/{mode}/list" in args[0]:
+                mock_resp.json.return_value = mock_tmdb_responses["genres"]
+            return mock_resp
 
+        mock_get.side_effect = mock_response_side_effect
+        return mock_get
 
-def test_query_tmdb_api_error(setup_tmdb_error_tests, caplog):
-    """Test TMDB query with API error."""
-    setup_tmdb_error_tests("api_error")
-    
-    with caplog.at_level(logging.ERROR):
-        results = query_tmdb("movie", "The Matrix")
-        
-        assert len(results) == 0
-        assert "Error querying TMDB API for movie: API Error" in caplog.text
+    return _setup_mocks
 
 
 @pytest.fixture
@@ -310,66 +228,8 @@ def tmdb_confidence_test_data():
                     "genre_ids": [],
                 }
             ]
-        }
+        },
     }
-
-
-def test_query_tmdb_confidence_calculation(tmdb_confidence_test_data, mock_api_response, mock_http_requests):
-    """Test confidence calculation in TMDB query."""
-    mock_get, _ = mock_http_requests
-    mock_get.side_effect = None
-    mock_get.return_value = mock_api_response
-    
-    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), patch("preprocessing.media_apis._get_genre_map", return_value={}):
-        # Test exact match
-        mock_api_response.json.return_value = tmdb_confidence_test_data["exact_match"]
-        exact_results = query_tmdb("movie", "Inception")
-
-        # Test similar match
-        mock_api_response.json.return_value = tmdb_confidence_test_data["similar_match"]
-        similar_results = query_tmdb("movie", "Inception")
-
-        # Test different match
-        mock_api_response.json.return_value = tmdb_confidence_test_data["different_match"]
-        different_results = query_tmdb("movie", "Inception")
-
-        # Verify confidence scores
-        assert exact_results[0]["confidence"] > similar_results[0]["confidence"]
-        assert similar_results[0]["confidence"] > different_results[0]["confidence"]
-
-
-def test_query_tmdb_limits_results(tmdb_confidence_test_data, mock_api_response, mock_http_requests):
-    """Test that TMDB query limits results to top 5."""
-    mock_get, _ = mock_http_requests
-    mock_get.side_effect = None
-    mock_get.return_value = mock_api_response
-    
-    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), patch("preprocessing.media_apis._get_genre_map", return_value={}):
-        # Create mock response with more than 5 results
-        mock_api_response.json.return_value = tmdb_confidence_test_data["many_results"]
-
-        # Call the function
-        results = query_tmdb("movie", "Movie")
-
-        # Verify results are limited to 5
-        assert len(results) == 5
-
-
-def test_query_tmdb_handles_missing_fields(tmdb_confidence_test_data, mock_api_response, mock_http_requests):
-    """Test that TMDB query handles missing fields gracefully."""
-    mock_get, _ = mock_http_requests
-    mock_get.side_effect = None
-    mock_get.return_value = mock_api_response
-    
-    with patch.dict(os.environ, {"TMDB_API_KEY": "fake_key"}), patch("preprocessing.media_apis._get_genre_map", return_value={}):
-        # Create mock response with missing fields
-        mock_api_response.json.return_value = tmdb_confidence_test_data["missing_fields"]
-
-        # Call the function
-        results = query_tmdb("movie", "Movie")
-
-        # Verify that results missing a release date are omitted
-        assert len(results) == 0
 
 
 @pytest.fixture
@@ -423,86 +283,31 @@ def mock_igdb_responses():
                 ],
             },
         ],
-        "empty": []
+        "empty": [],
     }
 
 
 @pytest.fixture
 def setup_igdb_mocks(mock_igdb_responses, mock_api_response, mock_http_requests):
     """Setup mocks for IGDB API tests."""
+
     def _setup_mocks(response_type="games", error_type=None):
         _, mock_post = mock_http_requests
-        
-        with patch.dict(
-            os.environ,
-            {
-                "IGDB_CLIENT_ID": "fake_client_id",
-                "IGDB_CLIENT_SECRET": "fake_client_secret",
-            }
-        ):
-            if error_type == "missing_credentials":
-                os.environ.clear()
-                return None
-                
-            if error_type == "api_error":
-                mock_post.side_effect = requests.RequestException("API Error")
-                return mock_post
-            
-            mock_api_response.json.return_value = mock_igdb_responses[response_type]
-            mock_post.return_value = mock_api_response
-            mock_post.side_effect = None
+
+        if error_type == "missing_credentials":
+            os.environ.clear()
+            return None
+
+        if error_type == "api_error":
+            mock_post.side_effect = requests.RequestException("API Error")
             return mock_post
+
+        mock_api_response.json.return_value = mock_igdb_responses[response_type]
+        mock_post.return_value = mock_api_response
+        mock_post.side_effect = None
+        return mock_post
+
     return _setup_mocks
-
-
-def test_calculate_title_similarity():
-    """Test the title similarity calculation function."""
-    test_cases = [
-        # (title1, title2, expected_range)
-        ("The Witcher 3", "The Witcher 3", (1.0, 1.0)),  # Identical
-        ("The Witcher 3", "The Witcher III", (0.7, 1.0)),  # Similar
-        ("The Witcher 3", "Cyberpunk 2077", (0.0, 0.5)),  # Different
-        ("", "", (1.0, 1.0)),  # Empty
-        ("Title", "", (0.0, 0.2)),  # One empty
-    ]
-    
-    for title1, title2, (min_val, max_val) in test_cases:
-        similarity = _calculate_title_similarity(title1, title2)
-        assert min_val <= similarity <= max_val, f"Failed for {title1} vs {title2}"
-
-
-def test_get_igdb_token_success(setup_igdb_mocks):
-    """Test successful IGDB token retrieval."""
-    mock_post = setup_igdb_mocks("auth")
-    
-    token = _get_igdb_token()
-    
-    assert token == "mock_access_token"
-    mock_post.assert_called_once()
-    assert "'client_id': 'fake_client_id'" in str(mock_post.call_args)
-    assert "'client_secret': 'fake_client_secret'" in str(mock_post.call_args)
-
-
-def test_get_igdb_token_missing_credentials(setup_igdb_mocks, caplog):
-    """Test IGDB token retrieval with missing credentials."""
-    setup_igdb_mocks(error_type="missing_credentials")
-    
-    with caplog.at_level(logging.WARNING):
-        token = _get_igdb_token()
-        
-        assert token is None
-        assert "IGDB_CLIENT_ID or IGDB_CLIENT_SECRET not found" in caplog.text
-
-
-def test_get_igdb_token_api_error(setup_igdb_mocks, caplog):
-    """Test IGDB token retrieval with API error."""
-    mock_post = setup_igdb_mocks(error_type="api_error")
-    
-    with caplog.at_level(logging.ERROR):
-        token = _get_igdb_token()
-        
-        assert token is None
-        assert mock_post.called
 
 
 @pytest.fixture
@@ -528,8 +333,291 @@ def igdb_test_games():
             "genres": [],  # Empty list
             "platforms": [{"name": "PC"}],
             "cover": {"url": "thumb/image.jpg"},  # Malformed URL
-        }
+        },
     }
+
+
+@pytest.fixture
+def mock_openlibrary_responses():
+    """Mock responses for OpenLibrary API."""
+    return {
+        "success": {
+            "numFound": 2,
+            "start": 0,
+            "docs": [
+                {
+                    "key": "/works/OL45883W",
+                    "title": "The Hobbit",
+                    "author_name": ["J.R.R. Tolkien"],
+                    "first_publish_year": 1937,
+                    "subject": ["Fantasy", "Fiction", "Adventure"],
+                    "cover_i": 12345,
+                },
+                {
+                    "key": "/works/OL12345W",
+                    "title": "The Hobbit: An Unexpected Journey",
+                    "author_name": ["J.R.R. Tolkien", "Peter Jackson"],
+                    "first_publish_year": 2012,
+                    "subject": ["Fantasy", "Film Adaptation"],
+                    "cover_i": 67890,
+                },
+            ],
+        },
+        "empty": {"numFound": 0, "start": 0, "docs": []},
+        "missing_fields": {
+            "numFound": 1,
+            "start": 0,
+            "docs": [
+                {
+                    "key": "/works/OL12345W",
+                    "title": "Book With Missing Fields",
+                    # Missing: author_name, first_publish_year, subject, cover_i
+                }
+            ],
+        },
+        "malformed": {"malformed": "response"},  # Missing 'docs' key
+        "confidence_test": {
+            "numFound": 1,
+            "docs": [
+                {
+                    "title": "Lord of the Rings",
+                    "first_publish_year": 1954,
+                }
+            ],
+        },
+    }
+
+
+@pytest.fixture
+def setup_openlibrary_mocks(
+    mock_openlibrary_responses, mock_api_response, mock_http_requests
+):
+    """Setup mocks for OpenLibrary API tests."""
+
+    def _setup_mocks(response_type="success", error_type=None):
+        mock_get, _ = mock_http_requests
+
+        if error_type == "api_error":
+            mock_get.side_effect = requests.RequestException("API Error")
+            return mock_get
+
+        mock_api_response.json.return_value = mock_openlibrary_responses[response_type]
+        mock_get.return_value = mock_api_response
+        mock_get.side_effect = None
+        return mock_get
+
+    return _setup_mocks
+
+
+def test_get_genre_map(mock_api_response, mock_http_requests):
+    """Test getting and caching the genre map."""
+    mock_get, _ = mock_http_requests
+    mock_api_response.json.return_value = GENRE_RESPONSE
+    mock_get.return_value = mock_api_response
+    mock_get.side_effect = None  # Override the default side_effect
+
+    expected_genre_map = {
+        genre["id"]: genre["name"] for genre in GENRE_MAPPING
+    }
+
+    # First call should make the API request
+    genre_map = _get_genre_map("movie")
+    assert mock_get.call_count == 1
+    assert genre_map == expected_genre_map
+
+    # Second call should use the cached value
+    genre_map = _get_genre_map("movie")
+    assert mock_get.call_count == 1
+    assert genre_map == expected_genre_map
+
+    # Different mode should make a new request
+    genre_map = _get_genre_map("tv")
+    assert mock_get.call_count == 2
+    assert genre_map == expected_genre_map
+
+
+def test_query_tmdb_movie_success(setup_tmdb_mocks):
+    """Test successful TMDB movie query."""
+    mock_get = setup_tmdb_mocks("movie")
+
+    # Call the function
+    results = query_tmdb("movie", "The Matrix")
+
+    # Verify results
+    assert len(results) == 2
+    assert results[0]["canonical_title"] == "The Matrix"
+    assert results[0]["type"] == "Movie"
+    assert results[0]["tags"]["genre"] == ["Action", "Science Fiction"]
+    assert results[0]["tags"]["release_year"] == "1999"
+    assert results[0]["confidence"] > 0.7  # High confidence for exact match
+    assert results[0]["source"] == "tmdb"
+    assert "poster_path" in results[0]
+
+
+def test_query_tmdb_tv_success(setup_tmdb_mocks):
+    """Test successful TMDB TV query."""
+    mock_get = setup_tmdb_mocks("tv")
+
+    # Call the function
+    results = query_tmdb("tv", "Stranger Things")
+
+    # Verify results
+    assert len(results) == 1
+    assert results[0]["canonical_title"] == "Stranger Things"
+    assert results[0]["type"] == "TV Show"
+    assert "Drama" in results[0]["tags"]["genre"]
+    assert results[0]["tags"]["release_year"] == "2016"
+    assert results[0]["confidence"] > 0.7  # High confidence for exact match
+    assert results[0]["source"] == "tmdb"
+
+
+def test_query_tmdb_no_api_key(setup_tmdb_error_tests, caplog):
+    """Test TMDB query with no API key."""
+    setup_tmdb_error_tests("no_api_key")
+
+    with caplog.at_level(logging.WARNING):
+        results = query_tmdb("movie", "The Matrix")
+
+        assert len(results) == 0
+        assert "TMDB_API_KEY not found in environment variables" in caplog.text
+
+
+def test_query_tmdb_empty_results(setup_tmdb_error_tests):
+    """Test TMDB query with empty results."""
+    setup_tmdb_error_tests("empty_results")
+
+    results = query_tmdb("movie", "NonexistentMovie12345")
+
+    assert len(results) == 0
+
+
+def test_query_tmdb_api_error(setup_tmdb_error_tests, caplog):
+    """Test TMDB query with API error."""
+    setup_tmdb_error_tests("api_error")
+
+    with caplog.at_level(logging.ERROR):
+        results = query_tmdb("movie", "The Matrix")
+
+        assert len(results) == 0
+        assert "Error querying TMDB API for movie: API Error" in caplog.text
+
+
+def test_query_tmdb_confidence_calculation(
+    tmdb_confidence_test_data, mock_api_response, mock_http_requests
+):
+    """Test confidence calculation in TMDB query."""
+    mock_get, _ = mock_http_requests
+    mock_get.side_effect = None
+    mock_get.return_value = mock_api_response
+
+    with patch("preprocessing.media_apis._get_genre_map", return_value={}):
+        # Test exact match
+        mock_api_response.json.return_value = tmdb_confidence_test_data["exact_match"]
+        exact_results = query_tmdb("movie", "Inception")
+
+        # Test similar match
+        mock_api_response.json.return_value = tmdb_confidence_test_data["similar_match"]
+        similar_results = query_tmdb("movie", "Inception")
+
+        # Test different match
+        mock_api_response.json.return_value = tmdb_confidence_test_data[
+            "different_match"
+        ]
+        different_results = query_tmdb("movie", "Inception")
+
+        # Verify confidence scores
+        assert exact_results[0]["confidence"] > similar_results[0]["confidence"]
+        assert similar_results[0]["confidence"] > different_results[0]["confidence"]
+
+
+def test_query_tmdb_limits_results(
+    tmdb_confidence_test_data, mock_api_response, mock_http_requests
+):
+    """Test that TMDB query limits results to top 5."""
+    mock_get, _ = mock_http_requests
+    mock_get.side_effect = None
+    mock_get.return_value = mock_api_response
+
+    with patch("preprocessing.media_apis._get_genre_map", return_value={}):
+        # Create mock response with more than 5 results
+        mock_api_response.json.return_value = tmdb_confidence_test_data["many_results"]
+
+        # Call the function
+        results = query_tmdb("movie", "Movie")
+
+        # Verify results are limited to 5
+        assert len(results) == 5
+
+
+def test_query_tmdb_handles_missing_fields(
+    tmdb_confidence_test_data, mock_api_response, mock_http_requests
+):
+    """Test that TMDB query handles missing fields gracefully."""
+    mock_get, _ = mock_http_requests
+    mock_get.side_effect = None
+    mock_get.return_value = mock_api_response
+
+    with patch("preprocessing.media_apis._get_genre_map", return_value={}):
+        # Create mock response with missing fields
+        mock_api_response.json.return_value = tmdb_confidence_test_data[
+            "missing_fields"
+        ]
+
+        # Call the function
+        results = query_tmdb("movie", "Movie")
+
+        # Verify that results missing a release date are omitted
+        assert len(results) == 0
+
+
+def test_calculate_title_similarity():
+    """Test the title similarity calculation function."""
+    test_cases = [
+        # (title1, title2, expected_range)
+        ("The Witcher 3", "The Witcher 3", (1.0, 1.0)),  # Identical
+        ("The Witcher 3", "The Witcher III", (0.7, 1.0)),  # Similar
+        ("The Witcher 3", "Cyberpunk 2077", (0.0, 0.5)),  # Different
+        ("", "", (1.0, 1.0)),  # Empty
+        ("Title", "", (0.0, 0.2)),  # One empty
+    ]
+
+    for title1, title2, (min_val, max_val) in test_cases:
+        similarity = _calculate_title_similarity(title1, title2)
+        assert min_val <= similarity <= max_val, f"Failed for {title1} vs {title2}"
+
+
+def test_get_igdb_token_success(setup_igdb_mocks):
+    """Test successful IGDB token retrieval."""
+    mock_post = setup_igdb_mocks("auth")
+
+    token = _get_igdb_token()
+
+    assert token == "mock_access_token"
+    mock_post.assert_called_once()
+    assert "'client_id': 'fake_client_id'" in str(mock_post.call_args)
+    assert "'client_secret': 'fake_client_secret'" in str(mock_post.call_args)
+
+
+def test_get_igdb_token_missing_credentials(setup_igdb_mocks, caplog):
+    """Test IGDB token retrieval with missing credentials."""
+    setup_igdb_mocks(error_type="missing_credentials")
+
+    with caplog.at_level(logging.WARNING):
+        token = _get_igdb_token()
+
+        assert token is None
+        assert "IGDB_CLIENT_ID or IGDB_CLIENT_SECRET not found" in caplog.text
+
+
+def test_get_igdb_token_api_error(setup_igdb_mocks, caplog):
+    """Test IGDB token retrieval with API error."""
+    mock_post = setup_igdb_mocks(error_type="api_error")
+
+    with caplog.at_level(logging.ERROR):
+        token = _get_igdb_token()
+
+        assert token is None
+        assert mock_post.called
 
 
 def test_format_igdb_entry(igdb_test_games):
@@ -570,7 +658,7 @@ def test_format_igdb_entry_partial_fields(igdb_test_games):
 def test_query_igdb_success(setup_igdb_mocks):
     """Test successful IGDB query."""
     mock_post = setup_igdb_mocks("games")
-    
+
     with patch("preprocessing.media_apis._get_igdb_token", return_value="mock_token"):
         results = query_igdb("The Witcher 3")
 
@@ -600,10 +688,12 @@ def test_query_igdb_no_token():
 def test_query_igdb_api_error(setup_igdb_mocks, caplog):
     """Test IGDB query with API error."""
     mock_post = setup_igdb_mocks(error_type="api_error")
-    
-    with patch("preprocessing.media_apis._get_igdb_token", return_value="mock_token"), caplog.at_level(logging.ERROR):
+
+    with patch(
+        "preprocessing.media_apis._get_igdb_token", return_value="mock_token"
+    ), caplog.at_level(logging.ERROR):
         results = query_igdb("The Witcher 3")
-        
+
         assert len(results) == 0
         assert "Error querying IGDB API: API Error" in caplog.text
 
@@ -611,93 +701,19 @@ def test_query_igdb_api_error(setup_igdb_mocks, caplog):
 def test_query_igdb_empty_results(setup_igdb_mocks):
     """Test IGDB query with empty results."""
     mock_post = setup_igdb_mocks("empty")
-    
+
     with patch("preprocessing.media_apis._get_igdb_token", return_value="mock_token"):
         results = query_igdb("NonexistentGame12345")
-        
+
         assert len(results) == 0
-
-
-@pytest.fixture
-def mock_openlibrary_responses():
-    """Mock responses for OpenLibrary API."""
-    return {
-        "success": {
-            "numFound": 2,
-            "start": 0,
-            "docs": [
-                {
-                    "key": "/works/OL45883W",
-                    "title": "The Hobbit",
-                    "author_name": ["J.R.R. Tolkien"],
-                    "first_publish_year": 1937,
-                    "subject": ["Fantasy", "Fiction", "Adventure"],
-                    "cover_i": 12345,
-                },
-                {
-                    "key": "/works/OL12345W",
-                    "title": "The Hobbit: An Unexpected Journey",
-                    "author_name": ["J.R.R. Tolkien", "Peter Jackson"],
-                    "first_publish_year": 2012,
-                    "subject": ["Fantasy", "Film Adaptation"],
-                    "cover_i": 67890,
-                },
-            ],
-        },
-        "empty": {
-            "numFound": 0, 
-            "start": 0, 
-            "docs": []
-        },
-        "missing_fields": {
-            "numFound": 1,
-            "start": 0,
-            "docs": [
-                {
-                    "key": "/works/OL12345W",
-                    "title": "Book With Missing Fields",
-                    # Missing: author_name, first_publish_year, subject, cover_i
-                }
-            ],
-        },
-        "malformed": {
-            "malformed": "response"  # Missing 'docs' key
-        },
-        "confidence_test": {
-            "numFound": 1,
-            "docs": [
-                {
-                    "title": "Lord of the Rings",
-                    "first_publish_year": 1954,
-                }
-            ],
-        }
-    }
-
-
-@pytest.fixture
-def setup_openlibrary_mocks(mock_openlibrary_responses, mock_api_response, mock_http_requests):
-    """Setup mocks for OpenLibrary API tests."""
-    def _setup_mocks(response_type="success", error_type=None):
-        mock_get, _ = mock_http_requests
-        
-        if error_type == "api_error":
-            mock_get.side_effect = requests.RequestException("API Error")
-            return mock_get
-            
-        mock_api_response.json.return_value = mock_openlibrary_responses[response_type]
-        mock_get.return_value = mock_api_response
-        mock_get.side_effect = None
-        return mock_get
-    return _setup_mocks
 
 
 def test_query_openlibrary_success(setup_openlibrary_mocks):
     """Test successful OpenLibrary query."""
     mock_get = setup_openlibrary_mocks("success")
-    
+
     results = query_openlibrary("The Hobbit")
-    
+
     # Verify results
     assert len(results) == 2
     assert results[0]["canonical_title"] == "The Hobbit"
@@ -708,7 +724,7 @@ def test_query_openlibrary_success(setup_openlibrary_mocks):
     assert results[0]["confidence"] > 0.7  # High confidence for exact match
     assert results[0]["source"] == "openlibrary"
     assert "covers.openlibrary.org" in results[0]["poster_path"]
-    
+
     # Verify API call
     mock_get.assert_called_once()
     assert mock_get.call_args.kwargs["params"]["title"] == "The Hobbit"
@@ -717,19 +733,19 @@ def test_query_openlibrary_success(setup_openlibrary_mocks):
 def test_query_openlibrary_empty_results(setup_openlibrary_mocks):
     """Test OpenLibrary query with empty results."""
     setup_openlibrary_mocks("empty")
-    
+
     results = query_openlibrary("NonexistentBook12345")
-    
+
     assert len(results) == 0
 
 
 def test_query_openlibrary_api_error(setup_openlibrary_mocks, caplog):
     """Test OpenLibrary query with API error."""
     setup_openlibrary_mocks(error_type="api_error")
-    
+
     with caplog.at_level(logging.ERROR):
         results = query_openlibrary("The Hobbit")
-        
+
         assert len(results) == 0
         assert "Error querying Open Library API: API Error" in caplog.text
 
@@ -737,9 +753,9 @@ def test_query_openlibrary_api_error(setup_openlibrary_mocks, caplog):
 def test_query_openlibrary_missing_fields(setup_openlibrary_mocks):
     """Test OpenLibrary query with missing fields in response."""
     setup_openlibrary_mocks("missing_fields")
-    
+
     results = query_openlibrary("Book")
-    
+
     # Verify results handle missing a first_publish_year are omitted
     assert len(results) == 0
 
@@ -747,21 +763,21 @@ def test_query_openlibrary_missing_fields(setup_openlibrary_mocks):
 def test_query_openlibrary_malformed_response(setup_openlibrary_mocks):
     """Test OpenLibrary query with malformed response."""
     setup_openlibrary_mocks("malformed")
-    
+
     results = query_openlibrary("The Hobbit")
-    
+
     assert len(results) == 0
 
 
 def test_query_openlibrary_confidence_calculation(setup_openlibrary_mocks):
     """Test confidence calculation in OpenLibrary query."""
     mock_get = setup_openlibrary_mocks("confidence_test")
-    
+
     # Test with different search titles to test confidence calculation
     exact_results = query_openlibrary("Lord of the Rings")
     similar_results = query_openlibrary("The Lord of the Rings")
     different_results = query_openlibrary("Completely Different Title")
-    
+
     # Verify confidence scores
     assert exact_results[0]["confidence"] > similar_results[0]["confidence"]
     assert similar_results[0]["confidence"] > different_results[0]["confidence"]

--- a/tests/test_media_apis.py
+++ b/tests/test_media_apis.py
@@ -28,86 +28,91 @@ GENRE_MAPPING = [
 ]
 
 
-DEFAULT_BOOKS = [
-    {
-        "title": "The Hobbit",
-        "author_name": ["J.R.R. Tolkien"],
-        "first_publish_year": 1937,
-        "subject": ["Fantasy", "Fiction", "Adventure"],
-        "cover_i": 12345,
-    },
-    {
-        "title": "The Hobbit: An Unexpected Journey",
-        "author_name": ["J.R.R. Tolkien", "Peter Jackson"],
-        "first_publish_year": 2012,
-        "subject": ["Fantasy", "Film Adaptation"],
-        "cover_i": 67890,
-    },
-]
-DEFAULT_GAMES = [
-    {
-        "name": "The Witcher 3: Wild Hunt",
-        "first_release_date": 1431993600,  # May 19, 2015
-        "rating": 93.4,
-        "aggregated_rating": 91.2,
-        "cover": {
-            "url": "//images.igdb.com/igdb/image/upload/t_thumb/co1wyy.jpg",
-        },
-        "genres": [
-            {"name": "Role-playing (RPG)"},
-            {"name": "Adventure"},
+@pytest.fixture(name="mock_api_responses")
+def fixture_mock_api_responses():
+    """Mock API responses for different media types."""
+    return {
+        "book": [
+            {
+                "title": "The Hobbit",
+                "author_name": ["J.R.R. Tolkien"],
+                "first_publish_year": 1937,
+                "subject": ["Fantasy", "Fiction", "Adventure"],
+                "cover_i": 12345,
+            },
+            {
+                "title": "The Hobbit: An Unexpected Journey",
+                "author_name": ["J.R.R. Tolkien", "Peter Jackson"],
+                "first_publish_year": 2012,
+                "subject": ["Fantasy", "Film Adaptation"],
+                "cover_i": 67890,
+            },
         ],
-        "platforms": [
-            {"name": "PC"},
-            {"name": "PlayStation 4"},
+        "game": [
+            {
+                "name": "The Witcher 3: Wild Hunt",
+                "first_release_date": 1431993600,  # May 19, 2015
+                "rating": 93.4,
+                "aggregated_rating": 91.2,
+                "cover": {
+                    "url": "//images.igdb.com/igdb/image/upload/t_thumb/co1wyy.jpg",
+                },
+                "genres": [
+                    {"name": "Role-playing (RPG)"},
+                    {"name": "Adventure"},
+                ],
+                "platforms": [
+                    {"name": "PC"},
+                    {"name": "PlayStation 4"},
+                ],
+            },
+            {
+                "name": "The Witcher 3: Wild Hunt - Hearts of Stone",
+                "first_release_date": 1444694400,  # October 13, 2015
+                "rating": 87.5,
+                "cover": {
+                    "url": "//images.igdb.com/igdb/image/upload/t_thumb/co1wyz.jpg",
+                },
+                "genres": [
+                    {"name": "Role-playing (RPG)"},
+                    {"name": "Adventure"},
+                ],
+                "platforms": [
+                    {"name": "PC"},
+                    {"name": "PlayStation 4"},
+                    {"name": "Xbox One"},
+                ],
+            },
         ],
-    },
-    {
-        "name": "The Witcher 3: Wild Hunt - Hearts of Stone",
-        "first_release_date": 1444694400,  # October 13, 2015
-        "rating": 87.5,
-        "cover": {
-            "url": "//images.igdb.com/igdb/image/upload/t_thumb/co1wyz.jpg",
-        },
-        "genres": [
-            {"name": "Role-playing (RPG)"},
-            {"name": "Adventure"},
+        "movie": [
+            {
+                "title": "The Matrix",
+                "release_date": "1999-03-31",
+                "popularity": 50.0,
+                "vote_average": 8.7,
+                "poster_path": "/path/to/poster.jpg",
+                "genre_ids": [28, 878],  # Action, Sci-Fi
+            },
+            {
+                "title": "The Matrix Reloaded",
+                "release_date": "2003-05-15",
+                "popularity": 40.0,
+                "vote_average": 7.2,
+                "poster_path": "/path/to/poster2.jpg",
+                "genre_ids": [28, 878],
+            },
         ],
-        "platforms": [
-            {"name": "PC"},
-            {"name": "PlayStation 4"},
-            {"name": "Xbox One"},
+        "tv": [
+            {
+                "name": "Stranger Things",
+                "first_air_date": "2016-07-15",
+                "popularity": 80.0,
+                "vote_average": 8.5,
+                "poster_path": "/path/to/poster10.jpg",
+                "genre_ids": [18, 9648, 10765],  # Drama, Mystery, Sci-Fi & Fantasy
+            },
         ],
-    },
-]
-DEFAULT_MOVIES = [
-    {
-        "title": "The Matrix",
-        "release_date": "1999-03-31",
-        "popularity": 50.0,
-        "vote_average": 8.7,
-        "poster_path": "/path/to/poster.jpg",
-        "genre_ids": [28, 878],  # Action, Sci-Fi
-    },
-    {
-        "title": "The Matrix Reloaded",
-        "release_date": "2003-05-15",
-        "popularity": 40.0,
-        "vote_average": 7.2,
-        "poster_path": "/path/to/poster2.jpg",
-        "genre_ids": [28, 878],
-    },
-]
-DEFAULT_TV_SHOWS = [
-    {
-        "name": "Stranger Things",
-        "first_air_date": "2016-07-15",
-        "popularity": 80.0,
-        "vote_average": 8.5,
-        "poster_path": "/path/to/poster10.jpg",
-        "genre_ids": [18, 9648, 10765],  # Drama, Mystery, Sci-Fi & Fantasy
-    },
-]
+    }
 
 
 @pytest.fixture(autouse=True, name="mock_http_requests")
@@ -194,12 +199,12 @@ def fixture_mock_tmdb_response(mock_http_requests):
 
 
 @pytest.fixture(name="mock_igdb_response")
-def fixture_mock_igdb_response(mock_http_requests):
+def fixture_mock_igdb_response(mock_api_responses, mock_http_requests):
     """Mock the response for IGDB API."""
 
     def _mock_igdb_response(results=None):
         if results is None:
-            results = DEFAULT_GAMES
+            results = mock_api_responses["game"]
         _, mock_post = mock_http_requests
         mock_post.return_value.json.return_value = results
         mock_post.side_effect = None
@@ -209,12 +214,12 @@ def fixture_mock_igdb_response(mock_http_requests):
 
 
 @pytest.fixture(name="mock_openlibrary_response")
-def fixture_mock_openlibrary_response(mock_http_requests):
+def fixture_mock_openlibrary_response(mock_api_responses, mock_http_requests):
     """Mock responses for OpenLibrary API."""
 
     def _mock_openlibrary_response(results=None):
         if results is None:
-            results = DEFAULT_BOOKS
+            results = mock_api_responses["book"]
         mock_get, _ = mock_http_requests
         mock_get.return_value.json.return_value = {
             "docs": results,
@@ -251,9 +256,9 @@ def test_get_genre_map(mock_http_requests):
     assert genre_map == expected_genre_map
 
 
-def test_query_tmdb_movie_success(mock_tmdb_response, _mock_get_genre_map):
+def test_query_tmdb_movie_success(mock_api_responses, mock_tmdb_response, _mock_get_genre_map):
     """Test successful TMDB movie query."""
-    mock_tmdb_response(DEFAULT_MOVIES)
+    mock_tmdb_response(mock_api_responses["movie"])
 
     # Call the function
     results = query_tmdb("movie", "The Matrix")
@@ -269,9 +274,9 @@ def test_query_tmdb_movie_success(mock_tmdb_response, _mock_get_genre_map):
     assert "poster_path" in results[0]
 
 
-def test_query_tmdb_tv_success(mock_tmdb_response, _mock_get_genre_map):
+def test_query_tmdb_tv_success(mock_api_responses, mock_tmdb_response, _mock_get_genre_map):
     """Test successful TMDB TV query."""
-    mock_tmdb_response(DEFAULT_TV_SHOWS)
+    mock_tmdb_response(mock_api_responses["tv"])
 
     # Call the function
     results = query_tmdb("tv", "Stranger Things")
@@ -319,11 +324,11 @@ def test_query_tmdb_api_error(mock_http_requests, caplog, _mock_get_genre_map):
         assert "Error querying TMDB API for movie: API Error" in caplog.text
 
 
-def test_query_tmdb_confidence_calculation(mock_tmdb_response, _mock_get_genre_map):
+def test_query_tmdb_confidence_calculation(mock_api_responses, mock_tmdb_response, _mock_get_genre_map):
     """Test confidence calculation in TMDB query."""
     different_title = "Matrices and Their Many Uses in Mathematics"
     mock_tmdb_response(
-        DEFAULT_MOVIES
+        mock_api_responses["movie"]
         + [
             {
                 "title": different_title,
@@ -354,10 +359,10 @@ def test_query_tmdb_confidence_calculation(mock_tmdb_response, _mock_get_genre_m
     assert similar_results["confidence"] > different_results["confidence"]
 
 
-def test_query_tmdb_limits_results(mock_tmdb_response, _mock_get_genre_map):
+def test_query_tmdb_limits_results(mock_api_responses, mock_tmdb_response, _mock_get_genre_map):
     """Test that TMDB query limits results to top 5."""
     # Create mock response with more than 5 results
-    mock_tmdb_response(DEFAULT_MOVIES * 10)
+    mock_tmdb_response(mock_api_responses["movie"] * 10)
 
     # Call the function
     results = query_tmdb("movie", "Movie")
@@ -366,10 +371,10 @@ def test_query_tmdb_limits_results(mock_tmdb_response, _mock_get_genre_map):
     assert len(results) == 5
 
 
-def test_query_tmdb_handles_missing_fields(mock_tmdb_response, _mock_get_genre_map):
+def test_query_tmdb_handles_missing_fields(mock_api_responses, mock_tmdb_response, _mock_get_genre_map):
     """Test that TMDB query handles missing fields gracefully."""
     # Create mock response with missing release_date
-    unreleased_movies = [movie.copy() for movie in DEFAULT_MOVIES]
+    unreleased_movies = [movie.copy() for movie in mock_api_responses["movie"]]
     for movie in unreleased_movies:
         movie["release_date"] = None
     mock_tmdb_response(unreleased_movies)
@@ -379,7 +384,7 @@ def test_query_tmdb_handles_missing_fields(mock_tmdb_response, _mock_get_genre_m
     assert len(results) == 0
 
     # Create mock response with missing release_date
-    unreleased_tv = [show.copy() for show in DEFAULT_TV_SHOWS]
+    unreleased_tv = [show.copy() for show in mock_api_responses["tv"]]
     for show in unreleased_tv:
         show["first_air_date"] = None
     mock_tmdb_response(unreleased_tv)
@@ -425,9 +430,9 @@ def test_get_igdb_token_api_error(caplog, mock_http_requests):
         assert mock_post.called
 
 
-def test_format_igdb_entry():
+def test_format_igdb_entry(mock_api_responses):
     """Test formatting an IGDB game entry."""
-    result = _format_igdb_entry("The Witcher 3: Wild Hunt", DEFAULT_GAMES[0])
+    result = _format_igdb_entry("The Witcher 3: Wild Hunt", mock_api_responses["game"][0])
 
     assert result["canonical_title"] == "The Witcher 3: Wild Hunt"
     assert result["type"] == "Game"
@@ -440,9 +445,9 @@ def test_format_igdb_entry():
     assert "720p" in result["poster_path"]  # Should upgrade image quality
 
 
-def test_format_igdb_entry_unreleased():
+def test_format_igdb_entry_unreleased(mock_api_responses):
     """Test formatting an IGDB game entry with missing fields."""
-    test_game = DEFAULT_GAMES[0].copy()
+    test_game = mock_api_responses["game"][0].copy()
     test_game["first_release_date"] = None  # Simulate missing first_release_date
 
     result = _format_igdb_entry("Unreleased Game", test_game)
@@ -451,11 +456,11 @@ def test_format_igdb_entry_unreleased():
     assert result is None
 
 
-def test_format_igdb_entry_partial_fields():
+def test_format_igdb_entry_partial_fields(mock_api_responses):
     """Test formatting an IGDB game entry with partial fields."""
     test_game = {
-        "name": DEFAULT_GAMES[0].get("name"),
-        "first_release_date": DEFAULT_GAMES[0].get("first_release_date"),
+        "name": mock_api_responses["game"][0].get("name"),
+        "first_release_date": mock_api_responses["game"][0].get("first_release_date"),
     }
 
     result = _format_igdb_entry("Partial Game", test_game)
@@ -558,9 +563,9 @@ def test_query_openlibrary_api_error(caplog, mock_http_requests):
         assert "Error querying Open Library API: API Error" in caplog.text
 
 
-def test_query_openlibrary_missing_fields(mock_openlibrary_response):
+def test_query_openlibrary_missing_fields(mock_api_responses, mock_openlibrary_response):
     """Test OpenLibrary query with missing fields in response."""
-    unreleased_books = [book.copy() for book in DEFAULT_BOOKS]
+    unreleased_books = [book.copy() for book in mock_api_responses["book"]]
     for book in unreleased_books:
         book["first_publish_year"] = None
     mock_openlibrary_response(unreleased_books)
@@ -582,11 +587,11 @@ def test_query_openlibrary_malformed_response(mock_http_requests):
     assert len(results) == 0
 
 
-def test_query_openlibrary_confidence_calculation(mock_openlibrary_response):
+def test_query_openlibrary_confidence_calculation(mock_api_responses, mock_openlibrary_response):
     """Test confidence calculation in OpenLibrary query."""
     different_title = "The Fellowship of the Ring"
     mock_openlibrary_response(
-        DEFAULT_BOOKS + [{"title": different_title, "first_publish_year": 1954}]
+        mock_api_responses["book"] + [{"title": different_title, "first_publish_year": 1954}]
     )
 
     # Test with different search titles to test confidence calculation

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -9,12 +9,70 @@ from preprocessing import media_tagger
 from preprocessing.media_tagger import apply_tagging
 
 
+@pytest.fixture(autouse=True, name="mock_dependencies")
+def fixture_mock_dependencies():
+    """Mock dependencies to avoid actual API calls."""
+    with patch("preprocessing.media_tagger.load_hints") as mock_load_hints, patch(
+        "preprocessing.media_tagger.query_tmdb"
+    ) as mock_query_tmdb, patch(
+        "preprocessing.media_tagger.query_igdb"
+    ) as mock_query_igdb, patch(
+        "preprocessing.media_tagger.query_openlibrary"
+    ) as mock_query_openlibrary:
+        mock_load_hints.side_effect = RuntimeError("Unmocked load_hints attempted")
+        mock_query_tmdb.side_effect = RuntimeError("Unmocked query_tmdb attempted")
+        mock_query_igdb.side_effect = RuntimeError("Unmocked query_igdb attempted")
+        mock_query_openlibrary.side_effect = RuntimeError(
+            "Unmocked query_openlibrary attempted"
+        )
+        yield mock_load_hints, mock_query_tmdb, mock_query_igdb, mock_query_openlibrary
+
+
+@pytest.fixture(name="reset_dependency_mocks")
+def fixture_reset_dependency_mocks(mock_dependencies):
+    """Reset dependency mocks to avoid side effects between tests."""
+
+    def _reset_mocks():
+        """Reset all mocks to their initial state."""
+        mock_load_hints, mock_query_tmdb, mock_query_igdb, mock_query_openlibrary = (
+            mock_dependencies
+        )
+        mock_load_hints.reset_mock()
+        mock_query_tmdb.reset_mock()
+        mock_query_igdb.reset_mock()
+        mock_query_openlibrary.reset_mock()
+
+    return _reset_mocks
+
+
+@pytest.fixture(name="reset_query_cache")
+def fixture_reset_query_cache():
+    """Reset query cache."""
+
+    def _reset_query_cache():
+        media_tagger.QUERY_CACHE = {}
+        media_tagger.MEDIA_DB_API_CALL_COUNTS = {}
+
+    return _reset_query_cache
+
+
 @pytest.fixture(autouse=True)
-def reset_query_cache():
+def auto_reset_query_cache(reset_query_cache):
     """Reset query cache before each test to ensure consistent state."""
-    media_tagger.QUERY_CACHE = {}
-    media_tagger.MEDIA_DB_API_CALL_COUNTS = {}
-    yield
+    reset_query_cache()
+
+
+@pytest.fixture(name="setup_hints_mock")
+def fixture_setup_hints_mock(mock_dependencies):
+    """Setup mock for hints loading."""
+    mock_load_hints, _, _, _ = mock_dependencies
+
+    def _setup_hints_mock(hints=None):
+        mock_load_hints.return_value = hints or {}
+        mock_load_hints.side_effect = None
+        return mock_load_hints
+
+    return _setup_hints_mock
 
 
 @pytest.fixture(name="sample_entries")
@@ -23,7 +81,8 @@ def fixture_sample_entries():
     return [
         {"title": "FF7", "started_dates": ["2023-01-01"], "finished_dates": []},
         {"title": "The Hobbit", "started_dates": [], "finished_dates": ["2023-02-15"]},
-        {"title": "Succesion", "started_dates": ["2023-03-10"], "finished_dates": []},
+        {"title": "Succession", "started_dates": ["2023-03-10"], "finished_dates": []},
+        {"title": "The Hobbit", "started_dates": ["2023-04-18"], "finished_dates": []},
     ]
 
 
@@ -41,15 +100,6 @@ def fixture_mock_api_responses():
                     "source": "tmdb",
                 }
             ],
-            "Matrix": [
-                {
-                    "canonical_title": "The Matrix",
-                    "type": "Movie",
-                    "confidence": 0.9,
-                    "source": "tmdb",
-                    "tags": {},
-                }
-            ],
         },
         "tv": {
             "Succession": [
@@ -59,15 +109,6 @@ def fixture_mock_api_responses():
                     "tags": {"genre": ["Drama"]},
                     "confidence": 0.9,
                     "source": "tmdb",
-                }
-            ],
-            "Game of Thrones": [
-                {
-                    "canonical_title": "Game of Thrones",
-                    "type": "TV Show",
-                    "confidence": 0.9,
-                    "source": "tmdb",
-                    "tags": {"genre": ["Drama", "Fantasy"]},
                 }
             ],
         },
@@ -86,16 +127,7 @@ def fixture_mock_api_responses():
                     "tags": {"platform": ["PS5"]},
                     "confidence": 0.85,
                     "source": "igdb",
-                }
-            ],
-            "Elden": [
-                {
-                    "canonical_title": "Elden Ring",
-                    "type": "Game",
-                    "confidence": 0.9,
-                    "source": "igdb",
-                    "tags": {},
-                }
+                },
             ],
         },
         "book": {
@@ -108,83 +140,76 @@ def fixture_mock_api_responses():
                     "source": "openlibrary",
                 }
             ],
-            "LOTR": [
-                {
-                    "canonical_title": "The Lord of the Rings",
-                    "type": "Book",
-                    "confidence": 0.9,
-                    "source": "openlibrary",
-                    "tags": {},
-                }
-            ],
         },
-        "empty": [],
-        "low_confidence": [
-            {
-                "canonical_title": "Final Fantasy VII",
-                "type": "Game",
-                "tags": {"platform": ["PS1"]},
-                "confidence": 0.2,
-                "source": "igdb",
-            },
-        ],
     }
 
 
 @pytest.fixture(name="setup_api_mocks")
-def fixture_setup_api_mocks(mock_api_responses):
+def fixture_setup_api_mocks(mock_dependencies, mock_api_responses):
     """Setup mocks for API calls in media tagger tests."""
-    def _setup_mocks(movie_response=None, tv_response=None, game_response=None, book_response=None):
-        with patch("preprocessing.media_tagger.query_tmdb") as mock_tmdb, \
-             patch("preprocessing.media_tagger.query_igdb") as mock_igdb, \
-             patch("preprocessing.media_tagger.query_openlibrary") as mock_openlibrary:
-            
-            # Configure mock returns based on parameters or use empty lists as default
-            def tmdb_side_effect(mode, title):
-                if mode == "movie" and movie_response is not None:
-                    return mock_api_responses["movie"].get(title, movie_response)
-                elif mode == "tv" and tv_response is not None:
-                    return mock_api_responses["tv"].get(title, tv_response)
-                return []
-            
-            mock_tmdb.side_effect = tmdb_side_effect
-            
-            def igdb_side_effect(title):
-                if game_response is not None:
-                    return mock_api_responses["game"].get(title, game_response)
-                return []
-            
-            mock_igdb.side_effect = igdb_side_effect
-            
-            def openlibrary_side_effect(title):
-                if book_response is not None:
-                    return mock_api_responses["book"].get(title, book_response)
-                return []
-            
-            mock_openlibrary.side_effect = openlibrary_side_effect
-            
-            return mock_tmdb, mock_igdb, mock_openlibrary
-    
+
+    def _setup_mocks(
+        movie_response=None, tv_response=None, game_response=None, book_response=None
+    ):
+        _, mock_tmdb, mock_igdb, mock_openlibrary = mock_dependencies
+        if (
+            movie_response is None
+            and tv_response is None
+            and game_response is None
+            and book_response is None
+        ):
+            movie_response = mock_api_responses["movie"]
+            tv_response = mock_api_responses["tv"]
+            game_response = mock_api_responses["game"]
+            book_response = mock_api_responses["book"]
+
+        # Configure mock returns based on parameters or use empty lists as default
+        def tmdb_side_effect(mode, title):
+            if mode == "movie" and movie_response is not None:
+                if isinstance(movie_response, list):
+                    return movie_response
+                return movie_response.get(title, [])
+            if mode == "tv" and tv_response is not None:
+                if isinstance(tv_response, list):
+                    return tv_response
+                return tv_response.get(title, [])
+            return []
+
+        mock_tmdb.side_effect = tmdb_side_effect
+
+        def igdb_side_effect(title):
+            if game_response is not None:
+                if isinstance(game_response, list):
+                    return game_response
+                return game_response.get(title, [])
+            return []
+
+        mock_igdb.side_effect = igdb_side_effect
+
+        def openlibrary_side_effect(title):
+            if book_response is not None:
+                if isinstance(book_response, list):
+                    return book_response
+                return book_response.get(title, [])
+            return []
+
+        mock_openlibrary.side_effect = openlibrary_side_effect
+
+        return mock_tmdb, mock_igdb, mock_openlibrary
+
     return _setup_mocks
 
 
-@pytest.fixture(name="setup_hints_mock")
-def fixture_setup_hints_mock():
-    """Setup mock for hints loading."""
-    def _setup_hints_mock(hints=None):
-        with patch("preprocessing.media_tagger.load_hints") as mock_hints:
-            mock_hints.return_value = hints or {}
-            return mock_hints
-    return _setup_hints_mock
-
-
-def test_apply_tagging_with_only_hints(sample_entries, sample_hints, setup_api_mocks, setup_hints_mock):
+def test_apply_tagging_with_only_hints(
+    sample_entries, sample_hints, setup_api_mocks, setup_hints_mock
+):
     """Test applying tagging with only hints and no API hits."""
     setup_hints_mock(sample_hints)
-    setup_api_mocks(movie_response=[], tv_response=[], game_response=[], book_response=[])
-    
-    with patch("os.path.exists", return_value=True):
-        tagged_entries = apply_tagging(sample_entries, "fake_path.yaml")
+    setup_api_mocks(
+        movie_response=[], tv_response=[], game_response=[], book_response=[]
+    )
+
+    tagged_entries = apply_tagging(sample_entries)
 
     # Check the entry that should match a hint
     entry = next(
@@ -201,30 +226,24 @@ def test_apply_tagging_with_only_hints(sample_entries, sample_hints, setup_api_m
     assert tagged_entry["source"] == "hint"
 
 
-def test_apply_tagging_with_api_calls(sample_entries, setup_api_mocks, setup_hints_mock):
+def test_apply_tagging_with_api_calls(
+    sample_entries, setup_api_mocks, setup_hints_mock
+):
     """Test applying tagging with API hits."""
     # Mock the API calls
-    succession_entry = [
-        entry for entry in sample_entries if entry["title"] == "Succesion"
-    ]
     setup_hints_mock()
-    setup_api_mocks(
-        tv_response=[{
-            "canonical_title": "Succession",
-            "type": "TV Show",
-            "tags": {"genre": ["Drama"]},
-            "confidence": 0.9,
-            "source": "tmdb",
-        }]
-    )
+    setup_api_mocks()
 
+    succession_entry = [
+        entry for entry in sample_entries if entry["title"] == "Succession"
+    ]
     tagged_entries = apply_tagging(succession_entry)
 
     # Assert entry is tagged correctly
     assert len(tagged_entries) == 1
     entry = tagged_entries[0]
     assert entry["canonical_title"] == "Succession"
-    assert entry["original_titles"][0] == "Succesion"
+    assert entry["original_titles"][0] == "Succession"
     assert "started_dates" in entry
     assert "finished_dates" in entry
 
@@ -235,14 +254,17 @@ def test_apply_tagging_with_api_calls(sample_entries, setup_api_mocks, setup_hin
     assert tagged_entry["source"] == "tmdb"
 
 
-def test_apply_tagging_api_failure(sample_entries, caplog, setup_api_mocks, setup_hints_mock):
+def test_apply_tagging_api_failure(
+    sample_entries, caplog, setup_api_mocks, setup_hints_mock
+):
     """Test applying tagging when API calls fail."""
     # Mock the API calls to fail
-    ff7_entry = [entry for entry in sample_entries if entry["title"] == "FF7"]
-
     setup_hints_mock()
-    setup_api_mocks(movie_response=[], tv_response=[], game_response=[], book_response=[])
+    setup_api_mocks(
+        movie_response=[], tv_response=[], game_response=[], book_response=[]
+    )
 
+    ff7_entry = [entry for entry in sample_entries if entry["title"] == "FF7"]
     with caplog.at_level(logging.WARNING):
         tagged_entries = apply_tagging(ff7_entry)
 
@@ -259,23 +281,26 @@ def test_apply_tagging_api_failure(sample_entries, caplog, setup_api_mocks, setu
         assert tagged_entry["source"] == "fallback"
 
 
-def test_apply_tagging_with_api_calls_and_hints(sample_entries, setup_api_mocks, setup_hints_mock):
+def test_apply_tagging_with_api_calls_and_hints(
+    mock_api_responses, sample_entries, setup_api_mocks, setup_hints_mock
+):
     """Test applying tagging with API hits and hints."""
     # Mock the API calls
-    ff7_entry = [entry for entry in sample_entries if entry["title"] == "FF7"]
-    
     setup_hints_mock()
-    mock_tmdb, mock_igdb, _ = setup_api_mocks(
-        movie_response=[{
-            "canonical_title": "Final Fantasy VII: Advent Children",
-            "type": "Movie",
-            "tags": {"genre": ["Animation"]},
-            "confidence": 0.7,
-            "source": "tmdb",
-        }],
-        game_response=mock_api_responses["game"]["FF7"]
+    setup_api_mocks(
+        movie_response=[
+            {
+                "canonical_title": "Final Fantasy VII: Advent Children",
+                "type": "Movie",
+                "tags": {"genre": ["Animation"]},
+                "confidence": 0.7,
+                "source": "tmdb",
+            }
+        ],
+        game_response=mock_api_responses["game"]["FF7"],
     )
 
+    ff7_entry = [entry for entry in sample_entries if entry["title"] == "FF7"]
     tagged_entries = apply_tagging(ff7_entry)
 
     # Assert entry is tagged correctly
@@ -293,17 +318,17 @@ def test_apply_tagging_with_api_calls_and_hints(sample_entries, setup_api_mocks,
     assert tagged_entry["source"] == "igdb"
 
 
-def test_apply_tagging_with_narrow_confidence(sample_entries, caplog, setup_api_mocks, setup_hints_mock):
+def test_apply_tagging_with_narrow_confidence(
+    caplog, sample_entries, setup_api_mocks, setup_hints_mock
+):
     """Test applying tagging when multiple top API hits have a close confidence score."""
     # Mock the API calls
-    hobbit_entry = [entry for entry in sample_entries if entry["title"] == "The Hobbit"]
-    
+    setup_api_mocks()
     setup_hints_mock()
-    setup_api_mocks(
-        movie_response=mock_api_responses["movie"]["The Hobbit"],
-        book_response=mock_api_responses["book"]["The Hobbit"]
-    )
 
+    hobbit_entry = [
+        entry for entry in sample_entries if entry["title"] == "The Hobbit"
+    ][:1]
     with caplog.at_level(logging.WARNING):
         tagged_entries = apply_tagging(hobbit_entry)
 
@@ -328,22 +353,23 @@ def test_apply_tagging_with_narrow_confidence(sample_entries, caplog, setup_api_
     assert tagged_entry["source"] == "openlibrary"
 
 
-def test_apply_tagging_fix_confidence_with_hint(sample_entries, caplog, setup_api_mocks, setup_hints_mock):
+def test_apply_tagging_fix_confidence_with_hint(
+    caplog, sample_entries, setup_api_mocks, setup_hints_mock
+):
     """Test applying tagging with multiple hits resolved by hints."""
     # Mock the API calls
-    hobbit_entry = [entry for entry in sample_entries if entry["title"] == "The Hobbit"]
-    
-    setup_hints_mock({
-        "The Hobbit": {
-            "type": "Movie",
+    setup_api_mocks()
+    setup_hints_mock(
+        {
+            "The Hobbit": {
+                "type": "Movie",
+            }
         }
-    })
-    
-    setup_api_mocks(
-        movie_response=mock_api_responses["movie"]["The Hobbit"],
-        book_response=mock_api_responses["book"]["The Hobbit"]
     )
 
+    hobbit_entry = [
+        entry for entry in sample_entries if entry["title"] == "The Hobbit"
+    ][:1]
     with caplog.at_level(logging.WARNING):
         tagged_entries = apply_tagging(hobbit_entry)
 
@@ -365,14 +391,18 @@ def test_apply_tagging_fix_confidence_with_hint(sample_entries, caplog, setup_ap
     assert tagged_entry["source"] == "tmdb"
 
 
-def test_apply_tagging_with_low_confidence(sample_entries, caplog, setup_api_mocks, setup_hints_mock):
+def test_apply_tagging_with_low_confidence(
+    caplog, sample_entries, mock_api_responses, setup_api_mocks, setup_hints_mock
+):
     """Test applying tagging when the top API hit has a low confidence score."""
     # Mock the API calls
-    ff7_entry = [entry for entry in sample_entries if entry["title"] == "FF7"]
-    
     setup_hints_mock()
-    setup_api_mocks(game_response=mock_api_responses["low_confidence"])
 
+    low_confidence_response = mock_api_responses["game"]["FF7"][0]
+    low_confidence_response["confidence"] = 0.2
+    setup_api_mocks(game_response=[low_confidence_response])
+
+    ff7_entry = [entry for entry in sample_entries if entry["title"] == "FF7"]
     with caplog.at_level(logging.WARNING):
         tagged_entries = apply_tagging(ff7_entry)
 
@@ -393,174 +423,136 @@ def test_apply_tagging_with_low_confidence(sample_entries, caplog, setup_api_moc
     assert tagged_entry["source"] == "igdb"
 
 
-def test_apply_tagging_only_queries_specified_type(setup_hints_mock):
+def test_apply_tagging_only_queries_specified_type(
+    sample_entries, setup_hints_mock, setup_api_mocks, reset_dependency_mocks
+):
     """
     Test that only the appropriate API is queried when hint specifies the type.
     This minimizes unnecessary API calls and improves performance.
     """
     # Create entries for each media type
-    movie_entry = [{"title": "Matrix", "action": "watched", "date": "2023-01-01"}]
-    tv_entry = [{"title": "Succession", "action": "watched", "date": "2023-01-01"}]
-    game_entry = [{"title": "Elden", "action": "played", "date": "2023-01-01"}]
-    book_entry = [{"title": "LOTR", "action": "read", "date": "2023-01-01"}]
+    movie_entries = [
+        entry for entry in sample_entries if entry["title"] == "The Hobbit"
+    ][:1]
+    tv_entries = [entry for entry in sample_entries if entry["title"] == "Succession"]
+    game_entries = [entry for entry in sample_entries if entry["title"] == "FF7"]
+    book_entries = [
+        entry for entry in sample_entries if entry["title"] == "The Hobbit"
+    ][1:]
 
-    with patch("preprocessing.media_tagger.query_tmdb") as mock_tmdb, \
-         patch("preprocessing.media_tagger.query_igdb") as mock_igdb, \
-         patch("preprocessing.media_tagger.query_openlibrary") as mock_openlibrary:
+    mock_tmdb, mock_igdb, mock_openlibrary = setup_api_mocks()
 
-        def reset_mocks():
-            mock_tmdb.reset_mock()
-            mock_igdb.reset_mock()
-            mock_openlibrary.reset_mock()
-            
-        # Configure mock returns
-        mock_tmdb.return_value = [
-            {
-                "canonical_title": "The Matrix",
-                "type": "Movie",
-                "confidence": 0.9,
-                "source": "tmdb",
-                "tags": {},
-            }
-        ]
-        
-        mock_igdb.return_value = [
-            {
-                "canonical_title": "Elden Ring",
-                "type": "Game",
-                "confidence": 0.9,
-                "source": "igdb",
-                "tags": {},
-            }
-        ]
-        
-        mock_openlibrary.return_value = [
-            {
-                "canonical_title": "The Lord of the Rings",
-                "type": "Book",
-                "confidence": 0.9,
-                "source": "openlibrary",
-                "tags": {},
-            }
-        ]
+    # Test Movie type
+    setup_hints_mock({"The Hobbit": {"type": "Movie"}})
+    apply_tagging(movie_entries)
 
-        # Test Movie type
-        setup_hints_mock({"Matrix": {"type": "Movie"}})
-        apply_tagging(movie_entry)
+    # Verify only movie API was called
+    mock_tmdb.assert_called_once_with("movie", "The Hobbit")
+    mock_igdb.assert_not_called()
+    mock_openlibrary.assert_not_called()
 
-        # Verify only movie API was called
-        mock_tmdb.assert_called_once_with("movie", "Matrix")
-        mock_igdb.assert_not_called()
-        mock_openlibrary.assert_not_called()
+    # Test TV type
+    reset_dependency_mocks()
+    setup_hints_mock({"Succession": {"type": "TV Show"}})
+    apply_tagging(tv_entries)
 
-        # Test TV type
-        reset_mocks()
-        setup_hints_mock({"Succession": {"type": "TV Show"}})
-        apply_tagging(tv_entry)
+    # Verify only TV API was called
+    mock_tmdb.assert_called_once_with("tv", "Succession")
+    mock_igdb.assert_not_called()
+    mock_openlibrary.assert_not_called()
 
-        # Verify only TV API was called
-        mock_tmdb.assert_called_once_with("tv", "Succession")
-        mock_igdb.assert_not_called()
-        mock_openlibrary.assert_not_called()
+    # Test Game type
+    reset_dependency_mocks()
+    setup_hints_mock({"FF7": {"type": "Game"}})
+    apply_tagging(game_entries)
 
-        # Test Game type
-        reset_mocks()
-        setup_hints_mock({"Elden": {"type": "Game"}})
-        apply_tagging(game_entry)
+    # Verify only game API was called
+    mock_tmdb.assert_not_called()
+    mock_igdb.assert_called_once_with("FF7")
+    mock_openlibrary.assert_not_called()
 
-        # Verify only game API was called
-        mock_tmdb.assert_not_called()
-        mock_igdb.assert_called_once_with("Elden")
-        mock_openlibrary.assert_not_called()
+    # Test Book type
+    reset_dependency_mocks()
+    setup_hints_mock({"The Hobbit": {"type": "Book"}})
+    apply_tagging(book_entries)
 
-        # Test Book type
-        reset_mocks()
-        setup_hints_mock({"LOTR": {"type": "Book"}})
-        apply_tagging(book_entry)
-
-        # Verify only book API was called
-        mock_tmdb.assert_not_called()
-        mock_igdb.assert_not_called()
-        mock_openlibrary.assert_called_once_with("LOTR")
+    # Verify only book API was called
+    mock_tmdb.assert_not_called()
+    mock_igdb.assert_not_called()
+    mock_openlibrary.assert_called_once_with("The Hobbit")
 
 
-def test_use_canonical_title_from_hint(setup_hints_mock):
+def test_use_canonical_title_from_hint(
+    sample_entries, mock_api_responses, setup_hints_mock, setup_api_mocks
+):
     """Test that the canonical_title from hint is used when querying APIs."""
-    entry = [{"title": "FF7", "action": "played", "date": "2023-01-01"}]
-
-    with patch("preprocessing.media_tagger.query_igdb") as mock_igdb:
-        # Set up mock hint with canonical_title
-        setup_hints_mock({
-            "FF7": {"canonical_title": "Final Fantasy VII Remake", "type": "Game"}
-        })
-        
-        mock_igdb.return_value = [
-            {
-                "canonical_title": "Final Fantasy VII Remake",
-                "type": "Game",
-                "confidence": 0.9,
-                "source": "igdb",
-                "tags": {"platform": ["PS5"]},
-            }
+    _, mock_igdb, _ = setup_api_mocks(
+        game_response=[
+            mock_api_responses["game"]["FF7"][1],
         ]
+    )
 
-        apply_tagging(entry)
+    # Set up mock hint with canonical_title
+    setup_hints_mock(
+        {"FF7": {"canonical_title": "Final Fantasy VII Remake", "type": "Game"}}
+    )
 
-        # Verify API was called with canonical_title from hint
-        mock_igdb.assert_called_once_with("Final Fantasy VII Remake")
+    ff7_entry = [entry for entry in sample_entries if entry["title"] == "FF7"]
+    apply_tagging(ff7_entry)
+
+    # Verify API was called with canonical_title from hint
+    mock_igdb.assert_called_once_with("Final Fantasy VII Remake")
 
 
-def test_season_extraction_in_tagging(setup_hints_mock):
+def test_season_extraction_in_tagging(
+    mock_api_responses,
+    setup_hints_mock,
+    setup_api_mocks,
+    reset_dependency_mocks,
+    reset_query_cache,
+):
     """Test that season information is correctly extracted and added back to canonical title."""
     # Test cases for different season formats
-    expected_title = "Game of Thrones"
+    expected_title = "Succession"
     test_cases = [
         {
-            "title": "Game of Thrones s1",
+            "title": "Succession s1",
             "expected_season": "s1",
         },
         {
-            "title": "Game of Thrones s01e02",
+            "title": "Succession s01e02",
             "expected_season": "s01",
         },
         {
-            "title": "Game of Thrones s1 e2",
+            "title": "Succession s1 e2",
             "expected_season": "s1",
         },
         {
-            "title": "Game of Thrones S1E1 ",
+            "title": "Succession S1E1 ",
             "expected_season": "s1",
         },
     ]
 
     for test_case in test_cases:
-        media_tagger.QUERY_CACHE = {}
+        reset_query_cache()
+        reset_dependency_mocks()
         entry = {"title": test_case["title"], "action": "started", "date": "2023-01-01"}
 
         setup_hints_mock()
-        
-        with patch("preprocessing.media_tagger.query_tmdb") as mock_tmdb:
-            # Set up mock return for TV API
-            mock_tmdb.return_value = [
-                {
-                    "canonical_title": "Game of Thrones",
-                    "type": "TV Show",
-                    "confidence": 0.9,
-                    "source": "tmdb",
-                    "tags": {"genre": ["Drama", "Fantasy"]},
-                }
-            ]
+        mock_tmdb, _, _ = setup_api_mocks(
+            tv_response=mock_api_responses["tv"]["Succession"],
+        )
 
-            tagged_entries = apply_tagging([entry])
+        tagged_entries = apply_tagging([entry])
 
-            # Verify season extraction and canonical title
-            assert len(tagged_entries) == 1
-            tagged_entry = tagged_entries[0]
-            assert (
-                tagged_entry["canonical_title"]
-                == f"Game of Thrones {test_case['expected_season']}"
-            )
-            assert tagged_entry["tagged"]["type"] == "TV Show"
+        # Verify season extraction and canonical title
+        assert len(tagged_entries) == 1
+        tagged_entry = tagged_entries[0]
+        assert (
+            tagged_entry["canonical_title"]
+            == f"Succession {test_case['expected_season']}"
+        )
+        assert tagged_entry["tagged"]["type"] == "TV Show"
 
-            # Verify API was called with the title without season information
-            mock_tmdb.assert_called_with("tv", expected_title)
+        # Verify API was called with the title without season information
+        mock_tmdb.assert_called_once_with("tv", expected_title)


### PR DESCRIPTION
- Create shared fixtures for mock responses
- Implement setup helper fixtures for each API
- Consolidate test data
- Reduce repetitive code
- Maintain the same test coverage

Autouse mocks to ensure no tests call dependencies
Reset mocks between tests to ensure independence
Provide a flexible and reusable way to set up mock responses for different scenarios by using sane defaults, but allowing passing in values

- Prevent actual HTTP requests during tests
- Provide a centralized way to mock HTTP requests
- Reduce boilerplate code in individual tests

The `mock_http_requests` fixture is `autouse=True`, which means it will automatically run for every test, ensuring no accidental real HTTP calls.

Refactors test setup by consolidating mock responses into shared fixtures, reducing repetitive code, and ensuring all HTTP calls are mocked automatically.

- Introduces mock_http_requests as an autouse fixture to prevent real HTTP calls
- Consolidates individual API setup into reusable helper fixtures
- Centralizes test data in sample_hints, replacing the previous LOTR entry with The Hobbit
