### PR TITLE
Add Pydantic validation also improve preprocessing based off testing in the wild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ lint:
 format:
 	black .
 
+.PHONY: preprocess
+preprocess:
+	env $$(grep -v 'ANTHROPIC' .env | xargs) python -m preprocessing.preprocess
+
 .PHONY: test
 test:
 	python -m pytest tests -v

--- a/preprocessing/hints.yaml
+++ b/preprocessing/hints.yaml
@@ -18,7 +18,6 @@ FF7:
   type: "Game"
 
 Hades:
-  canonical_title: "Hades"
   type: "Game"
 
 The Avengers:
@@ -30,12 +29,8 @@ The Avengers w/ Danyi:
   type: "Game"
 
 # Books
-LOTR:
-  canonical_title: "The Lord of the Rings"
-  type: "Book"
-
-Hobbit:
-  canonical_title: "The Hobbit"
+Sapiens:
+  canonical_title: "Sapiens: A Brief History of Mankind"
   type: "Book"
 
 # TV Shows
@@ -43,12 +38,29 @@ Captain Falcon & the Winter Soldier:
   canonical_title: "The Falcon and the Winter Soldier"
   type: "TV Show"
 
+Falcon & Winter Soldier:
+  canonical_title: "The Falcon and the Winter Soldier"
+  type: "TV Show"
+
 Finished WandaVision:
   canonical_title: "WandaVision"
   type: "TV Show"
 
+Loki:
+  type: "TV Show"
+
+Love, Death, & Robots:
+  type: "TV Show"
+
+Nevers:
+  canonical_title: "The Nevers"
+  type: "TV Show"
+
+Shadow & Bone:
+  canonical_title: "Shadow and Bone"
+  type: "TV Show"
+
 Snowpiercer:
-  canonical_title: "Snowpiercer"
   type: "TV Show"
 
 Star Trek Discovery:
@@ -56,20 +68,24 @@ Star Trek Discovery:
   type: "TV Show"
 
 # Movies
-Matrix:
-  canonical_title: "The Matrix"
+Mortal Combat:
+  canonical_title: "Mortal Kombat"
   type: "Movie"
 
 # Other
 Ant Design:
-  type: "Software Development"
-
+  type: "Ignored"
 BackstopJS:
-  type: "Software Development"
-
+  type: "Ignored"
 React Native Paper:
-  type: "Software Development"
-
+  type: "Ignored"
 Todo App testing:
-  canonical_title: "Chalk Project"
-  type: "Software Development"
+  type: "Ignored"
+Accessibility UX study:
+  type: "Ignored"
+Bald Move - Fargo:
+  type: "Ignored"
+MSF Doom Raids:
+  type: "Ignored"
+MSF DD4 (run 1):
+  type: "Ignored"

--- a/preprocessing/media_tagger.py
+++ b/preprocessing/media_tagger.py
@@ -76,11 +76,16 @@ def _combine_votes(
     # Sort API hits by confidence so we can check how close the to matches are
     if len(api_hits) > 1:
         api_hits.sort(key=lambda x: x["confidence"], reverse=True)
-        if api_hits[0]["confidence"] - api_hits[1]["confidence"] < 0.1:
+        close_api_hits = [
+            hit
+            for hit in api_hits
+            if hit["confidence"] >= api_hits[0]["confidence"] - 0.1
+        ]
+        if len(close_api_hits) > 1:
             logger.warning(
                 "Multiple API hits with close confidence for %s.\n\t%s",
                 entry,
-                ",\n\t".join(str(hit) for hit in api_hits),
+                ",\n\t".join(str(hit) for hit in close_api_hits),
             )
 
     best_api_hit = api_hits[0]

--- a/preprocessing/media_tagger.py
+++ b/preprocessing/media_tagger.py
@@ -162,13 +162,12 @@ def _tag_entry(title: str, hints: Dict) -> Dict:
         logger.info("Extracted season from title: %s", entry)
 
     # Apply hints if available
-    hint = None
-    for hint_key, hint_data in hints.items():
-        if hint_key == title:
-            logger.info("Applying hint for '%s' to entry '%s'", hint_key, entry)
-            title = hint_data.get("canonical_title", title)
-            hint = hint_data
-            break
+    hint = hints.get(title, None)
+    if hint:
+        logger.info("Applying hint for '%s' to entry '%s'", title, entry)
+        if hint.get("type") == "Ignored":
+            return None
+        title = hint.get("canonical_title", title)
 
     api_hits = []
     types_to_query = ["Movie", "TV Show", "Game", "Book"]
@@ -214,7 +213,10 @@ def _combine_similar_entries(tagged_entries: List[Dict]) -> List[Dict]:
     """
     canonical_groups = {}
     for entry in tagged_entries:
-        tagged_entry = entry.get("tagged", {})
+        tagged_entry = entry.get("tagged")
+        if tagged_entry is None:
+            continue
+
         canonical_key = (
             tagged_entry.get("canonical_title", ""),
             tagged_entry.get("type", ""),

--- a/preprocessing/models.py
+++ b/preprocessing/models.py
@@ -1,0 +1,64 @@
+"""
+Pydantic models for media entries.
+"""
+
+from typing import Dict, List, Optional, Union
+from datetime import date
+from pydantic import BaseModel, Field, validator
+
+
+class MediaTags(BaseModel):
+    """Tags for a media entry."""
+    genre: Optional[List[str]] = Field(default_factory=list)
+    platform: Optional[List[str]] = Field(default_factory=list)
+    mood: Optional[List[str]] = Field(default_factory=list)
+
+
+class TaggedEntry(BaseModel):
+    """Tagged metadata for a media entry."""
+    canonical_title: str
+    type: str
+    tags: MediaTags = Field(default_factory=MediaTags)
+    confidence: float
+    source: str
+    poster_path: Optional[str] = None
+
+
+class MediaEntry(BaseModel):
+    """
+    A media entry representing a book, movie, TV show, or game.
+    """
+    canonical_title: str
+    original_titles: List[str]
+    tagged: TaggedEntry
+    started_dates: List[str] = Field(default_factory=list)
+    finished_dates: List[str] = Field(default_factory=list)
+    
+    @validator('started_dates', 'finished_dates', each_item=True)
+    def validate_date_format(cls, v):
+        """Validate that dates are in ISO format (YYYY-MM-DD)."""
+        try:
+            date.fromisoformat(v)
+            return v
+        except ValueError:
+            raise ValueError(f"Date {v} is not in ISO format (YYYY-MM-DD)")
+    
+    @property
+    def duration_days(self) -> Optional[int]:
+        """Calculate the duration in days if both start and finish dates are available."""
+        if self.started_dates and self.finished_dates:
+            start = date.fromisoformat(min(self.started_dates))
+            finish = date.fromisoformat(max(self.finished_dates))
+            return (finish - start).days
+        return None
+    
+    @property
+    def status(self) -> str:
+        """Determine the status of the media entry."""
+        if self.started_dates and self.finished_dates:
+            return "completed"
+        elif self.started_dates:
+            return "in_progress"
+        elif self.finished_dates:
+            return "finished_only"
+        return "unknown"

--- a/preprocessing/models.py
+++ b/preprocessing/models.py
@@ -2,23 +2,25 @@
 Pydantic models for media entries.
 """
 
-from typing import Dict, List, Optional, Union
+from typing import Annotated, List, Optional
 from datetime import date
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field
 
 
 class MediaTags(BaseModel):
     """Tags for a media entry."""
-    genre: Optional[List[str]] = Field(default_factory=list)
-    platform: Optional[List[str]] = Field(default_factory=list)
-    mood: Optional[List[str]] = Field(default_factory=list)
+
+    genre: Annotated[Optional[List[str]], Field(default_factory=list)]
+    platform: Annotated[Optional[List[str]], Field(default_factory=list)]
+    mood: Annotated[Optional[List[str]], Field(default_factory=list)]
 
 
 class TaggedEntry(BaseModel):
     """Tagged metadata for a media entry."""
+
     canonical_title: str
     type: str
-    tags: MediaTags = Field(default_factory=MediaTags)
+    tags: Annotated[MediaTags, Field(default_factory=MediaTags)]
     confidence: float
     source: str
     poster_path: Optional[str] = None
@@ -28,21 +30,17 @@ class MediaEntry(BaseModel):
     """
     A media entry representing a book, movie, TV show, or game.
     """
+
     canonical_title: str
     original_titles: List[str]
     tagged: TaggedEntry
-    started_dates: List[str] = Field(default_factory=list)
-    finished_dates: List[str] = Field(default_factory=list)
-    
-    @validator('started_dates', 'finished_dates', each_item=True)
-    def validate_date_format(cls, v):
-        """Validate that dates are in ISO format (YYYY-MM-DD)."""
-        try:
-            date.fromisoformat(v)
-            return v
-        except ValueError:
-            raise ValueError(f"Date {v} is not in ISO format (YYYY-MM-DD)")
-    
+    started_dates: List[Annotated[str, Field(pattern=r"^\d{4}-\d{2}-\d{2}$")]] = Field(
+        default_factory=list
+    )
+    finished_dates: List[Annotated[str, Field(pattern=r"^\d{4}-\d{2}-\d{2}$")]] = Field(
+        default_factory=list
+    )
+
     @property
     def duration_days(self) -> Optional[int]:
         """Calculate the duration in days if both start and finish dates are available."""
@@ -51,14 +49,14 @@ class MediaEntry(BaseModel):
             finish = date.fromisoformat(max(self.finished_dates))
             return (finish - start).days
         return None
-    
+
     @property
     def status(self) -> str:
         """Determine the status of the media entry."""
         if self.started_dates and self.finished_dates:
             return "completed"
-        elif self.started_dates:
+        if self.started_dates:
             return "in_progress"
-        elif self.finished_dates:
+        if self.finished_dates:
             return "finished_only"
         return "unknown"

--- a/preprocessing/models.py
+++ b/preprocessing/models.py
@@ -10,9 +10,10 @@ from pydantic import BaseModel, Field
 class MediaTags(BaseModel):
     """Tags for a media entry."""
 
-    genre: Annotated[Optional[List[str]], Field(default_factory=list)]
-    platform: Annotated[Optional[List[str]], Field(default_factory=list)]
-    mood: Annotated[Optional[List[str]], Field(default_factory=list)]
+    author: Annotated[Optional[List[str]], Field(default=None)]
+    genre: Annotated[Optional[List[str]], Field(default=None)]
+    platform: Annotated[Optional[List[str]], Field(default=None)]
+    release_year: int
 
 
 class TaggedEntry(BaseModel):

--- a/preprocessing/preprocess.py
+++ b/preprocessing/preprocess.py
@@ -139,7 +139,7 @@ def process_and_save(
     for entry in tagged_entries:
         try:
             validated_entry = MediaEntry(**entry)
-            validated_entries.append(validated_entry.dict())
+            validated_entries.append(validated_entry.model_dump(exclude_none=True))
         except ValidationError as e:
             logger.warning(
                 "Failed to validate entry %s: %s",

--- a/preprocessing/preprocess.py
+++ b/preprocessing/preprocess.py
@@ -8,6 +8,8 @@ import json
 import logging
 from typing import List, Dict
 
+from pydantic import ValidationError
+
 from .media_extractor import RANGE_VERBS, extract_entries
 from .week_extractor import parse_row
 from .media_tagger import apply_tagging, get_media_db_api_calls
@@ -138,11 +140,15 @@ def process_and_save(
         try:
             validated_entry = MediaEntry(**entry)
             validated_entries.append(validated_entry.dict())
-        except Exception as e:
-            logger.warning("Failed to validate entry %s: %s", entry.get("canonical_title", "Unknown"), str(e))
-    
+        except ValidationError as e:
+            logger.warning(
+                "Failed to validate entry %s: %s",
+                entry.get("canonical_title", "Unknown"),
+                str(e),
+            )
+
     logger.info("Validated %d/%d entries", len(validated_entries), len(tagged_entries))
-    
+
     # Save to JSON
     try:
         with open(output_json, "w", encoding="utf-8") as f:

--- a/preprocessing/preprocess.py
+++ b/preprocessing/preprocess.py
@@ -19,15 +19,24 @@ from .models import MediaEntry
 logger = logging.getLogger(__name__)
 
 
-def _load_weekly_records(path: str) -> List[Dict]:
+def _load_weekly_records(
+    path: str, start_date: str = None, end_date: str = None
+) -> List[Dict]:
     """
     Load weekly records from a CSV file.
 
     Args:
         path: The file path to the CSV file.
+        start_date: Optional start date to filter records.
+        end_date: Optional end date to filter records.
 
     Returns:
         A list of dictionaries representing the weekly records.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        PermissionError: If there are permission issues accessing the file.
+        csv.Error: If there is an error parsing the CSV file.
     """
     records = []
     current_year = None
@@ -38,6 +47,10 @@ def _load_weekly_records(path: str) -> List[Dict]:
             for row in reader:
                 record, current_year = parse_row(row, current_year)
                 if record:
+                    if start_date and record.get("start_date") < start_date:
+                        continue
+                    if end_date and record.get("start_date") >= end_date:
+                        continue
                     records.append(record)
 
     except FileNotFoundError as e:
@@ -97,7 +110,10 @@ def _group_entries(individual_entries):
 
 
 def process_and_save(
-    input_csv: str, output_json: str, hints_path: str = None, limit: int = None
+    input_csv: str,
+    output_json: str,
+    start_date: str = None,
+    end_date: str = None,
 ) -> Dict:
     """
     Process the input CSV file and save the results to a JSON file.
@@ -105,14 +121,14 @@ def process_and_save(
     Args:
         input_csv: Path to the input CSV file.
         output_json: Path to the output JSON file.
-        hints_path: Path to the hints YAML file. Optional.
-        limit: Maximum number of entries to process. Optional.
+        start_date: Start date for filtering entries. Optional.
+        end_date: End date for filtering entries. Optional.
 
     Returns:
         Dictionary with statistics about the processing.
     """
     # Load weekly records
-    weekly_records = _load_weekly_records(input_csv)
+    weekly_records = _load_weekly_records(input_csv, start_date, end_date)
     logger.info("Loaded %d weekly records from %s", len(weekly_records), input_csv)
 
     # Extract media entries
@@ -125,10 +141,7 @@ def process_and_save(
     grouped_entries = _group_entries(individual_entries)
 
     # Apply tagging
-    if limit is not None:
-        grouped_entries = grouped_entries[:limit]
-        logger.warning("Limited to %d entries", limit)
-    tagged_entries = apply_tagging(grouped_entries, hints_path)
+    tagged_entries = apply_tagging(grouped_entries)
     logger.info("Tagged %d media entries", len(tagged_entries))
 
     # Calculate statistics
@@ -203,7 +216,8 @@ if __name__ == "__main__":
     final_stats = process_and_save(
         "preprocessing/raw_data/media_enjoyed.csv",
         "preprocessing/processed_data/media_entries.json",
-        limit=20,
+        start_date=None,
+        end_date="2021-07-01",
     )
 
     # Print statistics

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,22 +11,24 @@ from preprocessing.models import MediaEntry, TaggedEntry, MediaTags
 def test_media_tags_model():
     """Test the MediaTags model."""
     # Test with default values
-    tags = MediaTags()
-    assert tags.genre == []
-    assert tags.platform == []
-    assert tags.mood == []
+    tags = MediaTags(release_year=2023)
+    assert tags.release_year == 2023
+    assert tags.genre is None
+    assert tags.platform is None
 
     # Test with provided values
-    tags = MediaTags(genre=["Fantasy", "Adventure"], platform=["PS5"], mood=["Epic"])
+    tags = MediaTags(
+        genre=["Fantasy", "Adventure"], platform=["PS5"], release_year=2023
+    )
+    assert tags.release_year == 2023
     assert tags.genre == ["Fantasy", "Adventure"]
     assert tags.platform == ["PS5"]
-    assert tags.mood == ["Epic"]
 
     # Test serialization
-    tags_dict = tags.model_dump()
+    tags_dict = tags.model_dump(exclude_none=True)
     assert tags_dict["genre"] == ["Fantasy", "Adventure"]
     assert tags_dict["platform"] == ["PS5"]
-    assert tags_dict["mood"] == ["Epic"]
+    assert tags_dict["release_year"] == 2023
 
 
 def test_tagged_entry_model():
@@ -37,19 +39,21 @@ def test_tagged_entry_model():
         type="Game",
         confidence=0.92,
         source="igdb",
+        tags=MediaTags(release_year=2023),
     )
     assert tagged.canonical_title == "Final Fantasy VII Remake"
     assert tagged.type == "Game"
     assert tagged.confidence == 0.92
     assert tagged.source == "igdb"
-    assert tagged.tags.genre == []
+    assert tagged.tags.genre is None
+    assert tagged.tags.release_year == 2023
     assert tagged.poster_path is None
 
     # Test with all fields
     tagged = TaggedEntry(
         canonical_title="Final Fantasy VII Remake",
         type="Game",
-        tags=MediaTags(genre=["JRPG"], platform=["PS5"]),
+        tags=MediaTags(genre=["JRPG"], platform=["PS5"], release_year=2023),
         confidence=0.92,
         source="igdb",
         poster_path="https://example.com/poster.jpg",
@@ -58,6 +62,7 @@ def test_tagged_entry_model():
     assert tagged.type == "Game"
     assert tagged.tags.genre == ["JRPG"]
     assert tagged.tags.platform == ["PS5"]
+    assert tagged.tags.release_year == 2023
     assert tagged.confidence == 0.92
     assert tagged.source == "igdb"
     assert tagged.poster_path == "https://example.com/poster.jpg"
@@ -74,6 +79,7 @@ def test_media_entry_model():
             type="Game",
             confidence=0.92,
             source="igdb",
+            tags=MediaTags(release_year=2023),
         ),
     )
     assert entry.canonical_title == "Final Fantasy VII Remake"
@@ -90,7 +96,7 @@ def test_media_entry_model():
         tagged=TaggedEntry(
             canonical_title="Final Fantasy VII Remake",
             type="Game",
-            tags=MediaTags(genre=["JRPG"], platform=["PS5"]),
+            tags=MediaTags(genre=["JRPG"], platform=["PS5"], release_year=2023),
             confidence=0.92,
             source="igdb",
         ),
@@ -117,6 +123,7 @@ def test_media_entry_date_validation():
                 type="Book",
                 confidence=0.9,
                 source="openlibrary",
+                tags=MediaTags(release_year=2023),
             ),
             started_dates=["02/14/2023"],  # Invalid format
         )
@@ -130,7 +137,7 @@ def test_media_entry_json_serialization():
         tagged=TaggedEntry(
             canonical_title="Final Fantasy VII Remake",
             type="Game",
-            tags=MediaTags(genre=["JRPG"], platform=["PS5"]),
+            tags=MediaTags(genre=["JRPG"], platform=["PS5"], release_year=2023),
             confidence=0.92,
             source="igdb",
         ),
@@ -139,7 +146,7 @@ def test_media_entry_json_serialization():
     )
 
     # Convert to JSON and back
-    entry_json = entry.model_dump_json()
+    entry_json = entry.model_dump_json(exclude_none=True)
     entry_dict = json.loads(entry_json)
 
     # Verify structure
@@ -149,6 +156,7 @@ def test_media_entry_json_serialization():
     assert entry_dict["tagged"]["type"] == "Game"
     assert entry_dict["tagged"]["tags"]["genre"] == ["JRPG"]
     assert entry_dict["tagged"]["tags"]["platform"] == ["PS5"]
+    assert entry_dict["tagged"]["tags"]["release_year"] == 2023
     assert entry_dict["tagged"]["confidence"] == 0.92
     assert entry_dict["tagged"]["source"] == "igdb"
     assert entry_dict["started_dates"] == ["2023-02-14"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,6 @@
 """Unit tests for the Pydantic models."""
 
 import json
-from datetime import date
 
 import pytest
 from pydantic import ValidationError
@@ -16,15 +15,15 @@ def test_media_tags_model():
     assert tags.genre == []
     assert tags.platform == []
     assert tags.mood == []
-    
+
     # Test with provided values
     tags = MediaTags(genre=["Fantasy", "Adventure"], platform=["PS5"], mood=["Epic"])
     assert tags.genre == ["Fantasy", "Adventure"]
     assert tags.platform == ["PS5"]
     assert tags.mood == ["Epic"]
-    
+
     # Test serialization
-    tags_dict = tags.dict()
+    tags_dict = tags.model_dump()
     assert tags_dict["genre"] == ["Fantasy", "Adventure"]
     assert tags_dict["platform"] == ["PS5"]
     assert tags_dict["mood"] == ["Epic"]
@@ -37,7 +36,7 @@ def test_tagged_entry_model():
         canonical_title="Final Fantasy VII Remake",
         type="Game",
         confidence=0.92,
-        source="igdb"
+        source="igdb",
     )
     assert tagged.canonical_title == "Final Fantasy VII Remake"
     assert tagged.type == "Game"
@@ -45,7 +44,7 @@ def test_tagged_entry_model():
     assert tagged.source == "igdb"
     assert tagged.tags.genre == []
     assert tagged.poster_path is None
-    
+
     # Test with all fields
     tagged = TaggedEntry(
         canonical_title="Final Fantasy VII Remake",
@@ -53,7 +52,7 @@ def test_tagged_entry_model():
         tags=MediaTags(genre=["JRPG"], platform=["PS5"]),
         confidence=0.92,
         source="igdb",
-        poster_path="https://example.com/poster.jpg"
+        poster_path="https://example.com/poster.jpg",
     )
     assert tagged.canonical_title == "Final Fantasy VII Remake"
     assert tagged.type == "Game"
@@ -74,8 +73,8 @@ def test_media_entry_model():
             canonical_title="Final Fantasy VII Remake",
             type="Game",
             confidence=0.92,
-            source="igdb"
-        )
+            source="igdb",
+        ),
     )
     assert entry.canonical_title == "Final Fantasy VII Remake"
     assert entry.original_titles == ["FF7"]
@@ -83,7 +82,7 @@ def test_media_entry_model():
     assert entry.finished_dates == []
     assert entry.duration_days is None
     assert entry.status == "unknown"
-    
+
     # Test with all fields
     entry = MediaEntry(
         canonical_title="Final Fantasy VII Remake",
@@ -93,10 +92,10 @@ def test_media_entry_model():
             type="Game",
             tags=MediaTags(genre=["JRPG"], platform=["PS5"]),
             confidence=0.92,
-            source="igdb"
+            source="igdb",
         ),
         started_dates=["2023-02-14"],
-        finished_dates=["2023-03-07"]
+        finished_dates=["2023-03-07"],
     )
     assert entry.canonical_title == "Final Fantasy VII Remake"
     assert entry.original_titles == ["FF7", "Final Fantasy 7"]
@@ -117,9 +116,9 @@ def test_media_entry_date_validation():
                 canonical_title="Test",
                 type="Book",
                 confidence=0.9,
-                source="openlibrary"
+                source="openlibrary",
             ),
-            started_dates=["02/14/2023"]  # Invalid format
+            started_dates=["02/14/2023"],  # Invalid format
         )
 
 
@@ -133,16 +132,16 @@ def test_media_entry_json_serialization():
             type="Game",
             tags=MediaTags(genre=["JRPG"], platform=["PS5"]),
             confidence=0.92,
-            source="igdb"
+            source="igdb",
         ),
         started_dates=["2023-02-14"],
-        finished_dates=["2023-03-07"]
+        finished_dates=["2023-03-07"],
     )
-    
+
     # Convert to JSON and back
-    entry_json = entry.json()
+    entry_json = entry.model_dump_json()
     entry_dict = json.loads(entry_json)
-    
+
     # Verify structure
     assert entry_dict["canonical_title"] == "Final Fantasy VII Remake"
     assert entry_dict["original_titles"] == ["FF7", "Final Fantasy 7"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,156 @@
+"""Unit tests for the Pydantic models."""
+
+import json
+from datetime import date
+
+import pytest
+from pydantic import ValidationError
+
+from preprocessing.models import MediaEntry, TaggedEntry, MediaTags
+
+
+def test_media_tags_model():
+    """Test the MediaTags model."""
+    # Test with default values
+    tags = MediaTags()
+    assert tags.genre == []
+    assert tags.platform == []
+    assert tags.mood == []
+    
+    # Test with provided values
+    tags = MediaTags(genre=["Fantasy", "Adventure"], platform=["PS5"], mood=["Epic"])
+    assert tags.genre == ["Fantasy", "Adventure"]
+    assert tags.platform == ["PS5"]
+    assert tags.mood == ["Epic"]
+    
+    # Test serialization
+    tags_dict = tags.dict()
+    assert tags_dict["genre"] == ["Fantasy", "Adventure"]
+    assert tags_dict["platform"] == ["PS5"]
+    assert tags_dict["mood"] == ["Epic"]
+
+
+def test_tagged_entry_model():
+    """Test the TaggedEntry model."""
+    # Test with minimal required fields
+    tagged = TaggedEntry(
+        canonical_title="Final Fantasy VII Remake",
+        type="Game",
+        confidence=0.92,
+        source="igdb"
+    )
+    assert tagged.canonical_title == "Final Fantasy VII Remake"
+    assert tagged.type == "Game"
+    assert tagged.confidence == 0.92
+    assert tagged.source == "igdb"
+    assert tagged.tags.genre == []
+    assert tagged.poster_path is None
+    
+    # Test with all fields
+    tagged = TaggedEntry(
+        canonical_title="Final Fantasy VII Remake",
+        type="Game",
+        tags=MediaTags(genre=["JRPG"], platform=["PS5"]),
+        confidence=0.92,
+        source="igdb",
+        poster_path="https://example.com/poster.jpg"
+    )
+    assert tagged.canonical_title == "Final Fantasy VII Remake"
+    assert tagged.type == "Game"
+    assert tagged.tags.genre == ["JRPG"]
+    assert tagged.tags.platform == ["PS5"]
+    assert tagged.confidence == 0.92
+    assert tagged.source == "igdb"
+    assert tagged.poster_path == "https://example.com/poster.jpg"
+
+
+def test_media_entry_model():
+    """Test the MediaEntry model."""
+    # Test with minimal required fields
+    entry = MediaEntry(
+        canonical_title="Final Fantasy VII Remake",
+        original_titles=["FF7"],
+        tagged=TaggedEntry(
+            canonical_title="Final Fantasy VII Remake",
+            type="Game",
+            confidence=0.92,
+            source="igdb"
+        )
+    )
+    assert entry.canonical_title == "Final Fantasy VII Remake"
+    assert entry.original_titles == ["FF7"]
+    assert entry.started_dates == []
+    assert entry.finished_dates == []
+    assert entry.duration_days is None
+    assert entry.status == "unknown"
+    
+    # Test with all fields
+    entry = MediaEntry(
+        canonical_title="Final Fantasy VII Remake",
+        original_titles=["FF7", "Final Fantasy 7"],
+        tagged=TaggedEntry(
+            canonical_title="Final Fantasy VII Remake",
+            type="Game",
+            tags=MediaTags(genre=["JRPG"], platform=["PS5"]),
+            confidence=0.92,
+            source="igdb"
+        ),
+        started_dates=["2023-02-14"],
+        finished_dates=["2023-03-07"]
+    )
+    assert entry.canonical_title == "Final Fantasy VII Remake"
+    assert entry.original_titles == ["FF7", "Final Fantasy 7"]
+    assert entry.started_dates == ["2023-02-14"]
+    assert entry.finished_dates == ["2023-03-07"]
+    assert entry.duration_days == 21
+    assert entry.status == "completed"
+
+
+def test_media_entry_date_validation():
+    """Test date validation in the MediaEntry model."""
+    # Test with invalid date format
+    with pytest.raises(ValidationError):
+        MediaEntry(
+            canonical_title="Test",
+            original_titles=["Test"],
+            tagged=TaggedEntry(
+                canonical_title="Test",
+                type="Book",
+                confidence=0.9,
+                source="openlibrary"
+            ),
+            started_dates=["02/14/2023"]  # Invalid format
+        )
+
+
+def test_media_entry_json_serialization():
+    """Test JSON serialization of the MediaEntry model."""
+    entry = MediaEntry(
+        canonical_title="Final Fantasy VII Remake",
+        original_titles=["FF7", "Final Fantasy 7"],
+        tagged=TaggedEntry(
+            canonical_title="Final Fantasy VII Remake",
+            type="Game",
+            tags=MediaTags(genre=["JRPG"], platform=["PS5"]),
+            confidence=0.92,
+            source="igdb"
+        ),
+        started_dates=["2023-02-14"],
+        finished_dates=["2023-03-07"]
+    )
+    
+    # Convert to JSON and back
+    entry_json = entry.json()
+    entry_dict = json.loads(entry_json)
+    
+    # Verify structure
+    assert entry_dict["canonical_title"] == "Final Fantasy VII Remake"
+    assert entry_dict["original_titles"] == ["FF7", "Final Fantasy 7"]
+    assert entry_dict["tagged"]["canonical_title"] == "Final Fantasy VII Remake"
+    assert entry_dict["tagged"]["type"] == "Game"
+    assert entry_dict["tagged"]["tags"]["genre"] == ["JRPG"]
+    assert entry_dict["tagged"]["tags"]["platform"] == ["PS5"]
+    assert entry_dict["tagged"]["confidence"] == 0.92
+    assert entry_dict["tagged"]["source"] == "igdb"
+    assert entry_dict["started_dates"] == ["2023-02-14"]
+    assert entry_dict["finished_dates"] == ["2023-03-07"]

--- a/todo.md
+++ b/todo.md
@@ -35,14 +35,14 @@
 - [x] Implement `query_tmdb`
 - [x] Implement `query_igdb`
 - [x] Implement `query_openlibrary`
-- [ ] Batch titles to minimize requests to the APIs
+- [x] Batch titles to minimize requests to the APIs
 - [x] Trim seasons
 - [x] Use hints to limit the DBs queried for a title
 
 ## 5. JSON Schema & Validation
-- [ ] Define `MediaEntry` Pydantic model in `models.py`
-- [ ] Validate entries in `preprocess.py` and serialize to `media_entries.json`
-- [ ] Write tests in `tests/test_models.py` for model instantiation and JSON output
+- [x] Define `MediaEntry` Pydantic model in `models.py`
+- [x] Validate entries in `preprocess.py` and serialize to `media_entries.json`
+- [x] Write tests in `tests/test_models.py` for model instantiation and JSON output
 
 ## 6. Streamlit Skeleton
 - [ ] Create `app/streamlit_app.py`


### PR DESCRIPTION
In `preprocessing/models.py`, define Pydantic:
- `MediaEntry` model matching the JSON specification.

In `preprocess.py`:
- Validate tagged entries against `MediaEntry`.
- Serialize to `media_entries.json`.

Write tests in `tests/test_models.py` to ensure:
- Model instantiation with valid data.
- Correct JSON output structure.