### PR TITLE
Use a release_year from`hints.yaml` to narrow querying the TMDB, IGDB, and OpenLibrary APIs

### DIFF
--- a/preprocessing/hints.yaml
+++ b/preprocessing/hints.yaml
@@ -31,6 +31,7 @@ The Avengers w/ Danyi:
 # Books
 Sapiens:
   type: "Book"
+  release_year: "2011"
 
 # TV Shows
 Captain Falcon & the Winter Soldier:

--- a/preprocessing/hints.yaml
+++ b/preprocessing/hints.yaml
@@ -30,7 +30,6 @@ The Avengers w/ Danyi:
 
 # Books
 Sapiens:
-  canonical_title: "Sapiens: A Brief History of Mankind"
   type: "Book"
 
 # TV Shows

--- a/preprocessing/media_apis.py
+++ b/preprocessing/media_apis.py
@@ -326,11 +326,13 @@ def query_igdb(title: str, release_year: str = None) -> list:
         # Use the Apicalypse query format that IGDB requires
         # Search for games with name similar to the title
         # Include relevant fields for metadata
-        query = f"""
+        query_segments = [
+            f"""
             search "{title}";
             fields name, cover.url, first_release_date, genres.name, platforms.name, rating, aggregated_rating;
             where version_parent = null;
         """
+        ]
 
         # Add year filter if provided
         if release_year:

--- a/preprocessing/media_apis.py
+++ b/preprocessing/media_apis.py
@@ -343,14 +343,14 @@ def query_igdb(title: str, release_year: str = None) -> list:
                 end_timestamp = int(
                     time.mktime(time.strptime(f"{year}-12-31", "%Y-%m-%d"))
                 )
-                query += f" & first_release_date >= {start_timestamp} & first_release_date <= {end_timestamp};"
+                query_segments.append(
+                    f"first_release_date >= {start_timestamp} & first_release_date <= {end_timestamp}"
+                )
             except ValueError:
                 logger.warning("Invalid release_year format: %s", release_year)
-                query += ";"
-        else:
-            query += ";"
 
-        query += " limit 5;"
+        query_segments.append("limit 5")
+        query = "; ".join(query_segments) + ";"
 
         response = requests.post(
             "https://api.igdb.com/v4/games", headers=headers, data=query, timeout=10

--- a/preprocessing/media_apis.py
+++ b/preprocessing/media_apis.py
@@ -142,15 +142,22 @@ def query_tmdb(mode: str, title: str, release_year: str = None) -> list:
 
     # Search for TV shows or Movies
     try:
+        # Prepare parameters for the API call
+        params = {
+            "api_key": api_key,
+            "query": title,
+            "language": "en-US",
+            "page": 1,
+            "include_adult": "false",
+        }
+        
+        # Add year parameter if provided
+        if release_year:
+            params["year"] = release_year
+            
         tmdb_response = requests.get(
             f"{TMDB_BASE_URL}/search/{mode}",
-            params={
-                "api_key": api_key,
-                "query": title,
-                "language": "en-US",
-                "page": 1,
-                "include_adult": "false",
-            },
+            params=params,
             timeout=10,
         )
         tmdb_response.raise_for_status()

--- a/preprocessing/media_tagger.py
+++ b/preprocessing/media_tagger.py
@@ -105,7 +105,9 @@ def _combine_votes(
     return tagged_entry
 
 
-def _query_with_cache(media_type: str, title: str, release_year: str = None) -> List[Dict]:
+def _query_with_cache(
+    media_type: str, title: str, release_year: str = None
+) -> List[Dict]:
     """
     Query the appropriate API with caching to avoid redundant calls.
 
@@ -164,6 +166,7 @@ def _tag_entry(title: str, hints: Dict) -> Dict:
 
     # Apply hints if available
     hint = hints.get(title, None)
+    release_year_query_term = None
     if hint:
         logger.info("Applying hint for '%s' to entry '%s'", title, entry)
         if hint.get("type") == "Ignored":
@@ -171,7 +174,7 @@ def _tag_entry(title: str, hints: Dict) -> Dict:
         title = hint.get("canonical_title", title)
         # Extract release_year from hint if available
         if "release_year" in hint:
-            entry["release_year"] = hint["release_year"]
+            release_year_query_term = hint["release_year"]
 
     api_hits = []
     types_to_query = ["Movie", "TV Show", "Game", "Book"]
@@ -181,18 +184,15 @@ def _tag_entry(title: str, hints: Dict) -> Dict:
     elif hint and "type" in hint:
         types_to_query = [hint["type"]]
 
-    # Get release_year from entry or hint
-    release_year = entry.get("release_year")
-    
     # Query APIs with caching
     if "Movie" in types_to_query:
-        api_hits.extend(_query_with_cache("movie", title, release_year))
+        api_hits.extend(_query_with_cache("movie", title, release_year_query_term))
     if "TV Show" in types_to_query:
-        api_hits.extend(_query_with_cache("tv", title, release_year))
+        api_hits.extend(_query_with_cache("tv", title, release_year_query_term))
     if "Game" in types_to_query:
-        api_hits.extend(_query_with_cache("game", title, release_year))
+        api_hits.extend(_query_with_cache("game", title, release_year_query_term))
     if "Book" in types_to_query:
-        api_hits.extend(_query_with_cache("book", title, release_year))
+        api_hits.extend(_query_with_cache("book", title, release_year_query_term))
 
     # Combine votes from hints and API hits
     tagged_entry = _combine_votes(entry, api_hits, hint)

--- a/tests/test_media_apis.py
+++ b/tests/test_media_apis.py
@@ -276,6 +276,21 @@ def test_query_tmdb_movie_success(
     assert "poster_path" in results[0]
 
 
+def test_query_tmdb_with_release_year(
+    mock_api_responses, mock_tmdb_response, mock_http_requests, _mock_get_genre_map
+):
+    """Test TMDB query with release_year parameter."""
+    mock_get, _ = mock_http_requests
+    mock_tmdb_response(mock_api_responses["movie"])
+    
+    # Call the function with release_year
+    query_tmdb("movie", "The Matrix", "1999")
+    
+    # Verify that the year parameter was included in the API call
+    assert mock_get.call_count == 1
+    assert "year=1999" in str(mock_get.call_args)
+
+
 def test_query_tmdb_tv_success(
     mock_api_responses, mock_tmdb_response, _mock_get_genre_map
 ):
@@ -506,6 +521,19 @@ def test_query_igdb_success(_mock_get_igdb_token, mock_igdb_response):
     assert "The Witcher 3" in str(mock_post.call_args)
 
 
+def test_query_igdb_with_release_year(_mock_get_igdb_token, mock_igdb_response):
+    """Test IGDB query with release_year parameter."""
+    mock_post = mock_igdb_response()
+    
+    # Call the function with release_year
+    query_igdb("The Witcher 3", "2015")
+    
+    # Verify that the release_year was included in the query
+    assert mock_post.call_count == 1
+    assert "first_release_date >=" in str(mock_post.call_args)
+    assert "first_release_date <=" in str(mock_post.call_args)
+
+
 def test_query_igdb_no_token():
     """Test IGDB query with no token."""
     with patch("preprocessing.media_apis._get_igdb_token", return_value=None):
@@ -552,6 +580,18 @@ def test_query_openlibrary_success(mock_openlibrary_response):
     # Verify API call
     mock_get.assert_called_once()
     assert mock_get.call_args.kwargs["params"]["title"] == "The Hobbit"
+
+
+def test_query_openlibrary_with_release_year(mock_openlibrary_response):
+    """Test OpenLibrary query with release_year parameter."""
+    mock_get = mock_openlibrary_response()
+    
+    # Call the function with release_year
+    query_openlibrary("The Hobbit", "1937")
+    
+    # Verify that the first_publish_year parameter was included in the API call
+    assert mock_get.call_count == 1
+    assert mock_get.call_args.kwargs["params"]["first_publish_year"] == "1937"
 
 
 def test_query_openlibrary_empty_results(mock_openlibrary_response):

--- a/tests/test_media_apis.py
+++ b/tests/test_media_apis.py
@@ -282,13 +282,14 @@ def test_query_tmdb_with_release_year(
     """Test TMDB query with release_year parameter."""
     mock_get, _ = mock_http_requests
     mock_tmdb_response(mock_api_responses["movie"])
-    
+
     # Call the function with release_year
     query_tmdb("movie", "The Matrix", "1999")
-    
+
     # Verify that the year parameter was included in the API call
     assert mock_get.call_count == 1
-    assert "year=1999" in str(mock_get.call_args)
+    assert "year" in mock_get.call_args.kwargs["params"]
+    assert mock_get.call_args.kwargs["params"]["year"] == "1999"
 
 
 def test_query_tmdb_tv_success(
@@ -524,10 +525,10 @@ def test_query_igdb_success(_mock_get_igdb_token, mock_igdb_response):
 def test_query_igdb_with_release_year(_mock_get_igdb_token, mock_igdb_response):
     """Test IGDB query with release_year parameter."""
     mock_post = mock_igdb_response()
-    
+
     # Call the function with release_year
     query_igdb("The Witcher 3", "2015")
-    
+
     # Verify that the release_year was included in the query
     assert mock_post.call_count == 1
     assert "first_release_date >=" in str(mock_post.call_args)
@@ -585,10 +586,10 @@ def test_query_openlibrary_success(mock_openlibrary_response):
 def test_query_openlibrary_with_release_year(mock_openlibrary_response):
     """Test OpenLibrary query with release_year parameter."""
     mock_get = mock_openlibrary_response()
-    
+
     # Call the function with release_year
     query_openlibrary("The Hobbit", "1937")
-    
+
     # Verify that the first_publish_year parameter was included in the API call
     assert mock_get.call_count == 1
     assert mock_get.call_args.kwargs["params"]["first_publish_year"] == "1937"

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -241,8 +241,7 @@ def test_apply_tagging_with_release_year_hint(setup_api_mocks, setup_hints_mock)
     apply_tagging([entry])
 
     # Verify that the release_year was passed to the OpenLibrary API
-    mock_openlibrary.assert_called_once()
-    assert mock_openlibrary.call_args.kwargs["release_year"] == "2011"
+    mock_openlibrary.assert_called_once_with("Sapiens", "2011")
 
     # Verify that other APIs were not called since the hint specified Book type
     mock_tmdb.assert_not_called()

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -242,7 +242,7 @@ def test_apply_tagging_with_release_year_hint(setup_api_mocks, setup_hints_mock)
 
     # Verify that the release_year was passed to the OpenLibrary API
     mock_openlibrary.assert_called_once()
-    assert "2011" in str(mock_openlibrary.call_args)
+    assert mock_openlibrary.call_args.kwargs["release_year"] == "2011"
 
     # Verify that other APIs were not called since the hint specified Book type
     mock_tmdb.assert_not_called()

--- a/tests/test_media_tagger.py
+++ b/tests/test_media_tagger.py
@@ -226,6 +226,38 @@ def test_apply_tagging_with_only_hints(
     assert tagged_entry["source"] == "hint"
 
 
+def test_apply_tagging_with_release_year_hint(
+    caplog, setup_api_mocks, setup_hints_mock
+):
+    """Test applying tagging with release_year in the hint."""
+    # Setup a hint with release_year
+    setup_hints_mock(
+        {
+            "Sapiens": {
+                "type": "Book",
+                "release_year": "2011"
+            }
+        }
+    )
+    
+    # Mock the API calls
+    mock_tmdb, mock_igdb, mock_openlibrary = setup_api_mocks()
+    
+    # Create a test entry
+    entry = {"title": "Sapiens", "started_dates": ["2023-01-01"], "finished_dates": []}
+    
+    # Apply tagging
+    apply_tagging([entry])
+    
+    # Verify that the release_year was passed to the OpenLibrary API
+    mock_openlibrary.assert_called_once()
+    assert "2011" in str(mock_openlibrary.call_args)
+    
+    # Verify that other APIs were not called since the hint specified Book type
+    mock_tmdb.assert_not_called()
+    mock_igdb.assert_not_called()
+
+
 def test_apply_tagging_with_api_calls(
     sample_entries, setup_api_mocks, setup_hints_mock
 ):


### PR DESCRIPTION
For some cases such as the book Sapiens, there are so many matches that we need to give better hints to the APIs when tagging.  Let's add the ability to include a release year to the `hints.yaml` and use it when querying the TMDB, IGDB, and OpenLibrary APIs in `media_apis.py`

--
Adds support for an optional release_year hint to narrow API queries for media tagging across TMDB, IGDB, and OpenLibrary.

- Updated test mocks and test cases in tests/test_media_tagger.py and tests/test_media_apis.py to include and verify the release_year parameter.
- Modified the API query functions in preprocessing/media_tagger.py and preprocessing/media_apis.py to accept and propagate an optional release_year.
- Updated hints.yaml to include a release_year for specific media entries.