### PR TITLE
Make the short spans also fade out and in to feel a bit more dynamic

### DIFF
--- a/app/timeline_data.py
+++ b/app/timeline_data.py
@@ -13,9 +13,6 @@ import pandas as pd
 FADE_WEEKS_IN_PROGRESS = 4
 # Number of weeks for fade-in gradient for finish-only entries
 FADE_WEEKS_FINISH_ONLY = 4
-# Long duration threshold in weeks for applying fade effects,
-# calculated as the sum of fade weeks minus 2 to encourage some overlap
-MAX_SHORT_DURATION_WEEKS = FADE_WEEKS_IN_PROGRESS + FADE_WEEKS_FINISH_ONLY - 2
 MAX_OPACITY = 0.9  # Maximum opacity for bars
 MIN_OPACITY = 0.0  # Minimum opacity for faded bars
 # Number of subslices per week for finer granularity of the opacity gradient
@@ -83,47 +80,61 @@ def _add_span_bar(
     span_bars.append(span_bar)
 
 
-def _fade_out_span(span_bars: List[Dict], span_bar_template: Dict, start_week: int):
+def _fade_out_span(
+    span_bars: List[Dict],
+    span_bar_template: Dict,
+    start_week: int,
+    duration_slices: int = FADE_WEEKS_IN_PROGRESS * SLICES_PER_WEEK,
+):
     """
     Create a fade-out span for a long duration entry starting from the start week.
     Args:
         span_bars: List to append the created span bar dict
         span_bar_template: Template dict for the span bar
         start_week: The week index to start fading out from
+        duration_slices: Optional; the duration in weeks for the fade-out effect
     """
     bar_start = start_week * SLICES_PER_WEEK
     opacities = np.linspace(
         MAX_OPACITY, MIN_OPACITY, FADE_WEEKS_IN_PROGRESS * SLICES_PER_WEEK
     )
+    opacities = opacities[:duration_slices]
     for i, opacity in enumerate(opacities):
         _add_span_bar(
             span_bars,
             span_bar_template,
             bar_start + i,
             1,
-            opacity,
+            round(opacity, 2),
         )
 
 
-def _fade_in_span(span_bars: List[Dict], span_bar_template: Dict, end_week: int):
+def _fade_in_span(
+    span_bars: List[Dict],
+    span_bar_template: Dict,
+    end_week: int,
+    duration_slices: int = FADE_WEEKS_FINISH_ONLY * SLICES_PER_WEEK,
+):
     """
     Create a fade-in span for a long duration entry ending at the end week.
     Args:
         span_bars: List to append the created span bar dict
         span_bar_template: Template dict for the span bar
         end_week: The week index to end fading in at
+        duration_slices: Optional; the duration in weeks to fade in
     """
-    bar_start = (end_week + 1 - FADE_WEEKS_FINISH_ONLY) * SLICES_PER_WEEK
+    bar_start = (end_week + 1) * SLICES_PER_WEEK - duration_slices
     opacities = np.linspace(
         MIN_OPACITY, MAX_OPACITY, FADE_WEEKS_FINISH_ONLY * SLICES_PER_WEEK
     )
+    opacities = opacities[-duration_slices:]
     for i, opacity in enumerate(opacities):
         _add_span_bar(
             span_bars,
             span_bar_template,
             bar_start + i,
             1,
-            opacity,
+            round(opacity, 2),
         )
 
 
@@ -161,17 +172,19 @@ def _generate_bars(spans: List[Dict]) -> pd.DataFrame:
         if start_week is not None and end_week is not None:
             duration_weeks = end_week - start_week + 1
             span_bar_template["duration_weeks"] = duration_weeks
-            if duration_weeks <= MAX_SHORT_DURATION_WEEKS:
-                # Short duration, no fade needed
-                bar_start = start_week * SLICES_PER_WEEK
-                bar_duration = duration_weeks * SLICES_PER_WEEK
-                _add_span_bar(
-                    span_bars, span_bar_template, bar_start, bar_duration, MAX_OPACITY
-                )
-            else:
-                # Long duration, create 2 spans one fading out from the start and one fading in to the finish
-                _fade_out_span(span_bars, span_bar_template, start_week)
-                _fade_in_span(span_bars, span_bar_template, end_week)
+
+            duration_slices = duration_weeks * SLICES_PER_WEEK
+            duration_in = min(
+                duration_slices // 2, FADE_WEEKS_FINISH_ONLY * SLICES_PER_WEEK
+            )
+            duration_out = min(
+                duration_slices - duration_in, FADE_WEEKS_IN_PROGRESS * SLICES_PER_WEEK
+            )
+
+            if duration_out > 0:
+                _fade_out_span(span_bars, span_bar_template, start_week, duration_out)
+            if duration_in > 0:
+                _fade_in_span(span_bars, span_bar_template, end_week, duration_in)
 
         elif start_week is not None:
             _fade_out_span(span_bars, span_bar_template, start_week)

--- a/app/timeline_data.py
+++ b/app/timeline_data.py
@@ -92,7 +92,7 @@ def _fade_out_span(
         span_bars: List to append the created span bar dict
         span_bar_template: Template dict for the span bar
         start_week: The week index to start fading out from
-        duration_slices: Optional; the duration in weeks for the fade-out effect
+        duration_slices: Optional; the duration for the fade-out effect specified in slices
     """
     bar_start = start_week * SLICES_PER_WEEK
     opacities = np.linspace(
@@ -121,7 +121,7 @@ def _fade_in_span(
         span_bars: List to append the created span bar dict
         span_bar_template: Template dict for the span bar
         end_week: The week index to end fading in at
-        duration_slices: Optional; the duration in weeks to fade in
+        duration_slices: Optional; the duration for the fade-in effect specified in slices
     """
     bar_start = (end_week + 1) * SLICES_PER_WEEK - duration_slices
     opacities = np.linspace(

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -25,9 +25,9 @@ def main():
     """Main Streamlit application."""
 
     # Set page title and header
-    st.set_page_config(page_title="Media Timeline", page_icon="📚", layout="wide")
-
-    st.subheader("Interactive Visualization of Media Consumption")
+    st.set_page_config(
+        page_title="Media Timeline", page_icon=":umbrella:", layout="wide"
+    )
 
     # Add a reload button
     if st.button("Reload Data"):
@@ -38,23 +38,14 @@ def main():
     media_entries = load_media_entries()
 
     if media_entries:
-        st.write(f"Loaded {len(media_entries)} media entries")
+        # Prepare data for timeline
+        spans, min_date, max_date = extract_timeline_spans(media_entries)
+        weeks_df, bars_df = prepare_timeline_data(spans, min_date, max_date)
 
-        # Create tabs for different views
-        tab1, tab2 = st.tabs(["Timeline Visualization", "Raw JSON Data"])
+        # Create and display timeline chart
+        fig = create_timeline_chart(weeks_df, bars_df)
+        st.plotly_chart(fig, use_container_width=True)
 
-        with tab1:
-            # Prepare data for timeline
-            spans, min_date, max_date = extract_timeline_spans(media_entries)
-            weeks_df, bars_df = prepare_timeline_data(spans, min_date, max_date)
-
-            # Create and display timeline chart
-            fig = create_timeline_chart(weeks_df, bars_df)
-            st.plotly_chart(fig, use_container_width=True)
-
-        with tab2:
-            # Display raw JSON data
-            st.json(media_entries)
     else:
         st.warning("No media entries found. Please run the preprocessing script first.")
 


### PR DESCRIPTION
Enhances the visual dynamics by applying fade-in/out to short-duration spans and cleans up debugging elements from the Streamlit UI.

- Streamlit app: changed page icon, removed debug JSON view and subheader
- Timeline data: refactored fade logic to parameterize fade durations and apply to all spans
- Tests: updated expectations to cover contiguous fades for short spans and gaps for long spans; removed edge-case boundary tests