### PR TITLE
Add a fixed number of slots to the plot and allocate media entry spans into an available slot

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,4 @@
+[theme]
+base="light"
+backgroundColor="#191919"
+textColor="#888888"

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ preprocess:
 start:
 	streamlit run streamlit_app.py
 
+.PHONY: debug-start
+debug-start:
+	DEBUG=true streamlit run streamlit_app.py
+
 .PHONY: test
 test:
 	python -m pytest preprocessing/tests -v

--- a/app/tests/test_timeline_chart.py
+++ b/app/tests/test_timeline_chart.py
@@ -5,7 +5,8 @@ Tests for timeline chart generation functionality.
 import pandas as pd
 import plotly.graph_objects as go
 
-from app.timeline_chart import create_timeline_chart
+from app.timeline_chart import BAR_WIDTH, create_timeline_chart
+from app.utils import MAX_SLOTS
 
 
 def test_create_timeline_chart_happy_path():
@@ -55,19 +56,18 @@ def test_create_timeline_chart_happy_path():
 
     # Check layout properties
     layout = fig.layout
-    assert layout.width == 800
+    assert layout.height == 4000
     assert layout.plot_bgcolor == "rgba(25, 25, 25, 1)"
     assert layout.paper_bgcolor == "rgba(25, 25, 25, 1)"
     assert layout.font.color == "white"
 
     # Check x-axis configuration
-    assert layout.xaxis.range == (0, 0.5)  # 5 * BAR_WIDTH where BAR_WIDTH = 0.10
+    assert layout.xaxis.range == (0, MAX_SLOTS * BAR_WIDTH)
     assert layout.xaxis.showgrid is False
     assert layout.xaxis.showticklabels is False
     assert layout.xaxis.zeroline is False
 
     # Check y-axis configuration
-    assert layout.yaxis.autorange == "reversed"
     assert layout.yaxis.showgrid is False
     assert layout.yaxis.zeroline is False
     assert layout.yaxis.tickvals == (0, 1, 2, 3, 4, 5)

--- a/app/tests/test_timeline_chart.py
+++ b/app/tests/test_timeline_chart.py
@@ -29,6 +29,7 @@ def test_create_timeline_chart_happy_path():
             "opacity": [0.9, 0.7, 0.8],
             "bar_base": [0, 2, 4],
             "bar_y": [2, 1, 3],
+            "slot": [0, 1, 2],
             "start_week": [0, 2, 4],
             "end_week": [1, 2, 6],
             "start_date": ["2021-01-01", "2021-01-15", "2021-02-01"],
@@ -60,7 +61,7 @@ def test_create_timeline_chart_happy_path():
     assert layout.font.color == "white"
 
     # Check x-axis configuration
-    assert layout.xaxis.range == (0, 5)
+    assert layout.xaxis.range == (0, 0.5)  # 5 * BAR_WIDTH where BAR_WIDTH = 0.10
     assert layout.xaxis.showgrid is False
     assert layout.xaxis.showticklabels is False
     assert layout.xaxis.zeroline is False
@@ -116,6 +117,7 @@ def test_create_timeline_chart_with_nan_values():
             "opacity": [0.9, 0.8],
             "bar_base": [0, 1],
             "bar_y": [1, 1],
+            "slot": [0, 1],
             "start_week": [0, float("nan")],  # NaN for finish-only
             "end_week": [float("nan"), 1],  # NaN for in-progress
             "start_date": ["2021-01-01", None],
@@ -156,6 +158,7 @@ def test_create_timeline_chart_multiple_years():
             "opacity": [0.9],
             "bar_base": [0],
             "bar_y": [53],
+            "slot": [0],
             "start_week": [0],
             "end_week": [53],
             "start_date": ["2021-01-01"],

--- a/app/tests/test_timeline_chart.py
+++ b/app/tests/test_timeline_chart.py
@@ -56,20 +56,9 @@ def test_create_timeline_chart_happy_path():
 
     # Check layout properties
     layout = fig.layout
-    assert layout.height == 4000
-    assert layout.plot_bgcolor == "rgba(25, 25, 25, 1)"
-    assert layout.paper_bgcolor == "rgba(25, 25, 25, 1)"
-    assert layout.font.color == "white"
 
-    # Check x-axis configuration
+    # Check axis configuration
     assert layout.xaxis.range == (0, MAX_SLOTS * BAR_WIDTH)
-    assert layout.xaxis.showgrid is False
-    assert layout.xaxis.showticklabels is False
-    assert layout.xaxis.zeroline is False
-
-    # Check y-axis configuration
-    assert layout.yaxis.showgrid is False
-    assert layout.yaxis.zeroline is False
     assert layout.yaxis.tickvals == (0, 1, 2, 3, 4, 5)
 
     # Check that year annotations are present

--- a/app/tests/test_timeline_data.py
+++ b/app/tests/test_timeline_data.py
@@ -173,7 +173,7 @@ def test_generate_bars_long_duration_span():
     assert before_mid_bar["opacity"] == MIN_OPACITY
     assert after_mid_bar["opacity"] == MIN_OPACITY
     assert before_mid_bar["bar_base"] + 1 < after_mid_bar["bar_base"]
-    
+
     # Check that slots are assigned (could be same or different for fade-out/fade-in)
     assert "slot" in bars_df.columns
     assert all(bars_df["slot"] >= 0)
@@ -380,18 +380,20 @@ def test_allocate_slots_overflow():
     # Create more overlapping spans than we have slots
     spans = []
     for i in range(MAX_SLOTS + 2):
-        spans.append({
-            "entry_idx": i,
-            "title": f"Entry {i}",
-            "start_week": 0,
-            "end_week": 2,
-        })
+        spans.append(
+            {
+                "entry_idx": i,
+                "title": f"Entry {i}",
+                "start_week": 0,
+                "end_week": 2,
+            }
+        )
 
     slot_allocations = _allocate_slots(spans)
 
     # Only MAX_SLOTS entries should get allocated
     assert len(slot_allocations) == MAX_SLOTS
-    
+
     # Check that allocated slots are valid
     for slot in slot_allocations.values():
         assert 0 <= slot < MAX_SLOTS
@@ -419,12 +421,12 @@ def test_allocate_slots_long_span_reuse():
 
     # Both should get allocated
     assert len(slot_allocations) == 2
-    
+
     # Long span should have separate slots for fade-out and fade-in
     long_span_slots = slot_allocations[0]
     assert isinstance(long_span_slots, dict)
-    assert 'fade_out_slot' in long_span_slots
-    assert 'fade_in_slot' in long_span_slots
-    
+    assert "fade_out_slot" in long_span_slots
+    assert "fade_in_slot" in long_span_slots
+
     # Middle span should get a regular slot
     assert isinstance(slot_allocations[1], int)

--- a/app/tests/test_timeline_data.py
+++ b/app/tests/test_timeline_data.py
@@ -9,12 +9,14 @@ from app.timeline_data import (
     _generate_bars,
     _fade_in_span,
     _fade_out_span,
+    _allocate_slots,
     SLICES_PER_WEEK,
     FADE_WEEKS_IN_PROGRESS,
     FADE_WEEKS_FINISH_ONLY,
     MAX_OPACITY,
     MIN_OPACITY,
     MEDIA_TYPE_COLORS,
+    MAX_SLOTS,
 )
 
 
@@ -112,6 +114,7 @@ def test_generate_bars_short_duration_span():
     total_weeks = 4
     spans = [
         {
+            "entry_idx": 0,
             "title": "Short Movie",
             "start_week": start_week,
             "end_week": total_weeks,  # Use an odd number to ensure the fade out and in match mid week
@@ -131,6 +134,7 @@ def test_generate_bars_short_duration_span():
     assert first_bar["bar_base"] == start_week * SLICES_PER_WEEK
     assert first_bar["bar_y"] == 1
     assert first_bar["opacity"] == MAX_OPACITY
+    assert first_bar["slot"] == 0  # Should be assigned to first slot
 
     assert bars_df.iloc[-1]["opacity"] == MAX_OPACITY
     midpoint = len(bars_df) // 2
@@ -148,6 +152,7 @@ def test_generate_bars_long_duration_span():
 
     spans = [
         {
+            "entry_idx": 0,
             "title": "Long TV Show",
             "start_week": start_week,
             "end_week": total_weeks,
@@ -168,12 +173,18 @@ def test_generate_bars_long_duration_span():
     assert before_mid_bar["opacity"] == MIN_OPACITY
     assert after_mid_bar["opacity"] == MIN_OPACITY
     assert before_mid_bar["bar_base"] + 1 < after_mid_bar["bar_base"]
+    
+    # Check that slots are assigned (could be same or different for fade-out/fade-in)
+    assert "slot" in bars_df.columns
+    assert all(bars_df["slot"] >= 0)
+    assert all(bars_df["slot"] < MAX_SLOTS)
 
 
 def test_generate_bars_in_progress_span():
     """Test generating bars for in-progress spans (start_week only)."""
     spans = [
         {
+            "entry_idx": 0,
             "title": "In Progress Game",
             "start_week": 5,
             "end_week": None,
@@ -195,12 +206,14 @@ def test_generate_bars_in_progress_span():
         assert next_bar["title"] == "In Progress Game"
         assert next_bar["start_week"] == 5
         assert next_bar["end_week"] is None
+        assert next_bar["slot"] == 0  # Should be assigned to first slot
 
 
 def test_generate_bars_finish_only_span():
     """Test generating bars for finish-only spans (end_week only)."""
     spans = [
         {
+            "entry_idx": 0,
             "title": "Finished Book",
             "start_week": None,
             "end_week": 8,
@@ -222,12 +235,14 @@ def test_generate_bars_finish_only_span():
         assert next_bar["title"] == "Finished Book"
         assert next_bar["start_week"] is None
         assert next_bar["end_week"] == 8
+        assert next_bar["slot"] == 0  # Should be assigned to first slot
 
 
 def test_generate_bars_no_dates():
     """Test generating bars for spans with no dates (should be skipped)."""
     spans = [
         {
+            "entry_idx": 0,
             "title": "No Dates Entry",
             "start_week": None,
             "end_week": None,
@@ -244,6 +259,7 @@ def test_generate_bars_unknown_media_type():
     """Test generating bars for unknown media type."""
     spans = [
         {
+            "entry_idx": 0,
             "title": "Unknown Media",
             "type": "Podcast",  # Unknown type not in MEDIA_TYPE_COLORS
             "start_week": 0,
@@ -256,6 +272,7 @@ def test_generate_bars_unknown_media_type():
     first_bar = bars_df.iloc[0]
     assert first_bar["color"] == MEDIA_TYPE_COLORS["Unknown"]
     assert first_bar["type"] == "Podcast"
+    assert first_bar["slot"] == 0
 
 
 def test_generate_bars_mixed_spans():
@@ -303,11 +320,111 @@ def test_generate_bars_mixed_spans():
     movie_bars = bars_df[bars_df["entry_id"] == 0]
     assert all(movie_bars["color"] == MEDIA_TYPE_COLORS["Movie"])
     assert len(movie_bars) == 2 * SLICES_PER_WEEK  # 2 weeks fading
+    assert all(movie_bars["slot"] >= 0)
+    assert all(movie_bars["slot"] < MAX_SLOTS)
 
     game_bars = bars_df[bars_df["entry_id"] == 1]
     assert all(game_bars["color"] == MEDIA_TYPE_COLORS["Game"])
     assert len(game_bars) == FADE_WEEKS_IN_PROGRESS * SLICES_PER_WEEK
+    assert all(game_bars["slot"] >= 0)
+    assert all(game_bars["slot"] < MAX_SLOTS)
 
     book_bars = bars_df[bars_df["entry_id"] == 2]
     assert all(book_bars["color"] == MEDIA_TYPE_COLORS["Book"])
     assert len(book_bars) == FADE_WEEKS_FINISH_ONLY * SLICES_PER_WEEK
+    assert all(book_bars["slot"] >= 0)
+    assert all(book_bars["slot"] < MAX_SLOTS)
+
+
+def test_allocate_slots_basic():
+    """Test basic slot allocation functionality."""
+    spans = [
+        {
+            "entry_idx": 0,
+            "title": "First Entry",
+            "start_week": 0,
+            "end_week": 2,
+        },
+        {
+            "entry_idx": 1,
+            "title": "Second Entry",
+            "start_week": 1,
+            "end_week": 3,
+        },
+        {
+            "entry_idx": 2,
+            "title": "Third Entry",
+            "start_week": 4,
+            "end_week": 6,
+        },
+    ]
+
+    slot_allocations = _allocate_slots(spans)
+
+    # All entries should get slots
+    assert len(slot_allocations) == 3
+    assert 0 in slot_allocations
+    assert 1 in slot_allocations
+    assert 2 in slot_allocations
+
+    # First entry should get slot 0
+    assert slot_allocations[0] == 0
+    # Second entry overlaps with first, should get slot 1
+    assert slot_allocations[1] == 1
+    # Third entry doesn't overlap, can reuse slot 0
+    assert slot_allocations[2] == 0
+
+
+def test_allocate_slots_overflow():
+    """Test slot allocation when there are more overlapping spans than slots."""
+    # Create more overlapping spans than we have slots
+    spans = []
+    for i in range(MAX_SLOTS + 2):
+        spans.append({
+            "entry_idx": i,
+            "title": f"Entry {i}",
+            "start_week": 0,
+            "end_week": 2,
+        })
+
+    slot_allocations = _allocate_slots(spans)
+
+    # Only MAX_SLOTS entries should get allocated
+    assert len(slot_allocations) == MAX_SLOTS
+    
+    # Check that allocated slots are valid
+    for slot in slot_allocations.values():
+        assert 0 <= slot < MAX_SLOTS
+
+
+def test_allocate_slots_long_span_reuse():
+    """Test that long spans can reuse slots for fade-in after fade-out."""
+    long_duration = FADE_WEEKS_IN_PROGRESS + FADE_WEEKS_FINISH_ONLY + 2
+    spans = [
+        {
+            "entry_idx": 0,
+            "title": "Long Span",
+            "start_week": 0,
+            "end_week": long_duration,
+        },
+        {
+            "entry_idx": 1,
+            "title": "Middle Span",
+            "start_week": FADE_WEEKS_IN_PROGRESS + 1,
+            "end_week": FADE_WEEKS_IN_PROGRESS + 2,
+        },
+    ]
+
+    slot_allocations = _allocate_slots(spans)
+
+    # Both should get allocated
+    assert len(slot_allocations) == 2
+    
+    # Long span should have separate slots for fade-out and fade-in
+    long_span_slots = slot_allocations[0]
+    assert isinstance(long_span_slots, dict)
+    assert 'fade_out_slot' in long_span_slots
+    assert 'fade_in_slot' in long_span_slots
+    
+    # Middle span should get a regular slot
+    assert isinstance(slot_allocations[1], int)

--- a/app/timeline_chart.py
+++ b/app/timeline_chart.py
@@ -52,7 +52,7 @@ def create_timeline_chart(weeks_df: pd.DataFrame, bars_df: pd.DataFrame) -> go.F
 
     # Add bars for entries
     for _, next_bar in bars_df.iterrows():
-        x_offset = next_bar["entry_id"] * BAR_WIDTH
+        x_offset = next_bar["slot"] * BAR_WIDTH
 
         rgba_tuple = tuple(
             int(next_bar["color"].lstrip("#")[i : (i + 2)], 16) for i in (0, 2, 4)
@@ -101,7 +101,7 @@ def create_timeline_chart(weeks_df: pd.DataFrame, bars_df: pd.DataFrame) -> go.F
         margin={"l": 50, "r": 5, "t": 5, "b": 5},
         xaxis={
             "title": "",
-            "range": [0, 5],
+            "range": [0, 5 * BAR_WIDTH],
             "showgrid": False,
             "showticklabels": False,
             "zeroline": False,

--- a/app/timeline_chart.py
+++ b/app/timeline_chart.py
@@ -15,6 +15,8 @@ logger = logging.getLogger(__name__)
 
 BAR_WIDTH = 1.0
 BAR_SPACING = 0.05  # Spacing between bars on the x-axis
+HEIGHT_FACTOR = 4  # Increase this to stretch the chart vertically
+MIN_CHART_HEIGHT = 480
 
 
 def create_timeline_chart(weeks_df: pd.DataFrame, bars_df: pd.DataFrame) -> go.Figure:
@@ -101,7 +103,7 @@ def create_timeline_chart(weeks_df: pd.DataFrame, bars_df: pd.DataFrame) -> go.F
     min_week = weeks_df["week_index"].min()
     max_week = weeks_df["week_index"].max()
     fig.update_layout(
-        height=4000,
+        height=max(HEIGHT_FACTOR * max_week, MIN_CHART_HEIGHT),
         plot_bgcolor="rgba(25, 25, 25, 1)",
         paper_bgcolor="rgba(25, 25, 25, 1)",
         font={"color": "white"},

--- a/app/timeline_chart.py
+++ b/app/timeline_chart.py
@@ -3,12 +3,13 @@ Generate a timeline chart using Plotly for vizualizing media entries.
 """
 
 import logging
+import math
 
 import numpy as np
 import plotly.graph_objects as go
 import pandas as pd
 
-from app.utils import MAX_SLOTS
+from app.utils import MAX_SLOTS, is_debug_mode
 
 logger = logging.getLogger(__name__)
 
@@ -69,14 +70,18 @@ def create_timeline_chart(weeks_df: pd.DataFrame, bars_df: pd.DataFrame) -> go.F
             tooltip_list.append(f"Duration: {next_bar['duration_weeks']:.0f} week(s)")
         tooltip = "<br>".join(tooltip_list)
 
+        extra_spacing = (BAR_WIDTH - BAR_SPACING) * (
+            math.pow(1 - next_bar["opacity"], 2) / 12
+        )
+
         fig.add_trace(
             go.Bar(
-                x=[next_bar["slot"] * BAR_WIDTH + BAR_SPACING],
+                x=[next_bar["slot"] * BAR_WIDTH + BAR_SPACING + extra_spacing],
                 y=[next_bar["bar_y"]],
                 base=[next_bar["bar_base"]],
                 orientation="v",
                 marker_color=f"rgba{rgba_tuple}",
-                width=BAR_WIDTH - BAR_SPACING,
+                width=BAR_WIDTH - BAR_SPACING - 2 * extra_spacing,
                 hovertemplate=tooltip,
                 showlegend=False,
                 offsetgroup=1,
@@ -109,7 +114,7 @@ def create_timeline_chart(weeks_df: pd.DataFrame, bars_df: pd.DataFrame) -> go.F
         },
         yaxis={
             "range": [max_week + 10, min_week - 10],
-            "showgrid": False,
+            "showgrid": is_debug_mode(),
             "tickvals": weeks_df["week_index"].tolist(),
             "ticktext": tick_text,
             "zeroline": False,

--- a/app/timeline_data.py
+++ b/app/timeline_data.py
@@ -4,12 +4,13 @@ This module prepares media entries into spans for the timeline visualization
 
 import logging
 from datetime import datetime, timedelta
+import random
 from typing import Dict, List
 
 import numpy as np
 import pandas as pd
 
-from app.utils import MAX_SLOTS
+from app.utils import MAX_SLOTS, is_debug_mode
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +23,8 @@ MAX_OPACITY = 0.9  # Maximum opacity for bars
 MIN_OPACITY = 0.0  # Minimum opacity for faded bars
 # Number of subslices per week for finer granularity of the opacity gradient
 SLICES_PER_WEEK = 4
+# Number of weeks to skip before freeing a slot for a new entry
+VERTICAL_SPACING_WEEKS = 1
 
 # Color mapping for media types
 MEDIA_TYPE_COLORS = {
@@ -54,7 +57,9 @@ def _generate_week_axis(min_date: datetime, max_date: datetime) -> pd.DataFrame:
                 {
                     "week_index": week_index,
                     "year": current_date.year,
-                    "week_label": current_date.strftime("%b"),
+                    "week_label": current_date.strftime(
+                        "%b %d" if is_debug_mode() else "%b"
+                    ),
                 }
             )
             week_index += 1
@@ -143,21 +148,59 @@ def _fade_in_span(
         )
 
 
+def _future_blocks_clear(
+    future_blocks: List[Dict], start_slice: int, free_slice: int
+) -> bool:
+    """
+    Check if the future blocks do not overlap with the given slice range.
+
+    Args:
+        future_blocks: List of future block dictionaries
+        start_slice: Start slice index
+        free_slice: Free slice index
+
+    Returns:
+        True if no overlaps, False otherwise
+    """
+    for block in future_blocks:
+        if not (
+            block["free_slice"] <= start_slice or block["start_slice"] >= free_slice
+        ):
+            return False
+    return True
+
+
 def _allocate_slots(spans: List[Dict]) -> Dict[int, int]:
     """
     Allocate horizontal slots for spans to prevent overlapping.
+    Note we also pad out spans by an extra VERTICAL_SPACING_WEEKS to allow vertical spacing
 
     Args:
-        spans: List of span dictionaries sorted by start time
+        spans: List of span dictionaries
 
     Returns:
         Dictionary mapping entry_idx to slot number (0 to MAX_SLOTS-1)
     """
     slot_allocations = {}
-    # Track when each slot becomes free (slice index)
+
+    # Track any future fade-in blocks by slot to avoid collisions
+    future_blocks_by_slot = [[] for _ in range(MAX_SLOTS)]
+
+    # Track when each slot will be free (by slice index)
     slot_free_at = [0] * MAX_SLOTS
 
-    for span in spans:
+    # Sort spans by start time (including fade-in starts)
+    # This ensures that we can schedule by packing the earliest spans first
+    sorted_spans = sorted(
+        spans,
+        key=lambda x: (
+            x.get("start_week")
+            if x.get("start_week") is not None
+            else x.get("end_week", 0) + 1 - FADE_WEEKS_FINISH_ONLY
+        ),
+    )
+
+    for span in sorted_spans:
         start_week = span.get("start_week")
         end_week = span.get("end_week")
         entry_idx = span.get("entry_idx")
@@ -166,105 +209,54 @@ def _allocate_slots(spans: List[Dict]) -> Dict[int, int]:
             continue
 
         # Calculate the time range this span will occupy
-        if start_week is not None and end_week is not None:
-            # Full span - occupies from start to end
-            start_slice = start_week * SLICES_PER_WEEK
-            duration_weeks = end_week - start_week + 1
-            duration_slices = duration_weeks * SLICES_PER_WEEK
+        # Handles prepping a future block if this span will fade out and back in
+        if end_week is None:
+            end_week = start_week + FADE_WEEKS_IN_PROGRESS - 1
+        elif start_week is None:
+            start_week = end_week + 1 - FADE_WEEKS_FINISH_ONLY
 
-            # Check if span is long enough to have a gap between fade-out and fade-in
-            duration_in = min(
-                duration_slices // 2, FADE_WEEKS_FINISH_ONLY * SLICES_PER_WEEK
+        start_slice = start_week * SLICES_PER_WEEK
+        free_week = end_week + 1 + VERTICAL_SPACING_WEEKS
+        free_slice = free_week * SLICES_PER_WEEK
+
+        next_future_block = None
+        if free_week - start_week > FADE_WEEKS_IN_PROGRESS + FADE_WEEKS_FINISH_ONLY:
+            next_future_block = {
+                "start_slice": (free_week - FADE_WEEKS_FINISH_ONLY) * SLICES_PER_WEEK,
+                "free_slice": free_slice,
+                "entry_idx": entry_idx,
+            }
+            free_week = start_week + FADE_WEEKS_IN_PROGRESS + VERTICAL_SPACING_WEEKS
+            free_slice = free_week * SLICES_PER_WEEK
+
+        # Find a free slot for this span
+        # Sort slots by the first slot which is free earliest
+        sorted_slot_free_at = sorted(
+            enumerate(slot_free_at), key=lambda x: (x[1], random.random())
+        )
+
+        slot = None
+        for slot_to_check, _ in sorted_slot_free_at:
+            logger.info(
+                f"Checking slot {slot_to_check}, it will be free at {slot_free_at[slot_to_check]}.  {span.get('title')} requires start_slice {start_slice} and will block til free_slice {free_slice}"
             )
-            duration_out = min(
-                duration_slices - duration_in, FADE_WEEKS_IN_PROGRESS * SLICES_PER_WEEK
+            if slot_free_at[slot_to_check] <= start_slice and _future_blocks_clear(
+                future_blocks_by_slot[slot_to_check], start_slice, free_slice
+            ):
+
+                slot = slot_to_check
+                slot_free_at[slot] = free_slice
+                break
+
+        if slot is None:
+            logger.warning(
+                f"No available slots for span '{span.get('title')}' - skipping, start_date: {span.get('start_date')}, end_date: {span.get('end_date')}"
             )
+            continue
 
-            if duration_out + duration_in < duration_slices:
-                # Long span with gap - can reuse slot for fade-in
-                fade_out_end = start_slice + duration_out
-                fade_in_start = (end_week + 1) * SLICES_PER_WEEK - duration_in
-
-                # Find slot for fade-out
-                fade_out_slot = None
-                for slot in range(MAX_SLOTS):
-                    if slot_free_at[slot] <= start_slice:
-                        fade_out_slot = slot
-                        slot_free_at[slot] = fade_out_end
-                        break
-
-                # Find slot for fade-in (can be different)
-                fade_in_slot = None
-                for slot in range(MAX_SLOTS):
-                    if slot_free_at[slot] <= fade_in_start:
-                        fade_in_slot = slot
-                        slot_free_at[slot] = fade_in_start + duration_in
-                        break
-
-                if fade_out_slot is not None and fade_in_slot is not None:
-                    # Store both slots for this entry
-                    slot_allocations[entry_idx] = {
-                        "fade_out_slot": fade_out_slot,
-                        "fade_in_slot": fade_in_slot,
-                    }
-                else:
-                    logger.warning(
-                        f"No available slots for span '{span.get('title')}' - skipping"
-                    )
-            else:
-                # Short span - needs single slot for entire duration
-                end_slice = start_slice + duration_slices
-                slot = None
-                for s in range(MAX_SLOTS):
-                    if slot_free_at[s] <= start_slice:
-                        slot = s
-                        slot_free_at[s] = end_slice
-                        break
-
-                if slot is not None:
-                    slot_allocations[entry_idx] = slot
-                else:
-                    logger.warning(
-                        f"No available slots for span '{span.get('title')}' - skipping"
-                    )
-
-        elif start_week is not None:
-            # In-progress span
-            start_slice = start_week * SLICES_PER_WEEK
-            end_slice = start_slice + FADE_WEEKS_IN_PROGRESS * SLICES_PER_WEEK
-
-            slot = None
-            for s in range(MAX_SLOTS):
-                if slot_free_at[s] <= start_slice:
-                    slot = s
-                    slot_free_at[s] = end_slice
-                    break
-
-            if slot is not None:
-                slot_allocations[entry_idx] = slot
-            else:
-                logger.warning(
-                    f"No available slots for in-progress span '{span.get('title')}' - skipping"
-                )
-
-        else:
-            # Finish-only span
-            end_slice = (end_week + 1) * SLICES_PER_WEEK
-            start_slice = end_slice - FADE_WEEKS_FINISH_ONLY * SLICES_PER_WEEK
-
-            slot = None
-            for s in range(MAX_SLOTS):
-                if slot_free_at[s] <= start_slice:
-                    slot = s
-                    slot_free_at[s] = end_slice
-                    break
-
-            if slot is not None:
-                slot_allocations[entry_idx] = slot
-            else:
-                logger.warning(
-                    f"No available slots for finish-only span '{span.get('title')}' - skipping"
-                )
+        slot_allocations[entry_idx] = slot
+        if next_future_block:
+            future_blocks_by_slot[slot].append(next_future_block)
 
     return slot_allocations
 
@@ -276,23 +268,9 @@ def _generate_bars(spans: List[Dict]) -> pd.DataFrame:
         spans: List of dictionaries containing each span of media entry data for the timeline.
     Returns:
         DataFrame with columns: entry_id, title, type, color, start_date, start_week, end_date, end_week,
-            duration_weeks, tags, bar_base, bar_y, opacity, slot.
+            duration_weeks, tags, bar_base, bar_y, opacity, & slot.
     """
-    # Sort spans by start time for slot allocation
-    sorted_spans = sorted(
-        spans,
-        key=lambda x: (
-            (
-                x.get("start_week")
-                if x.get("start_week") is not None
-                else x.get("end_week", float("inf"))
-            ),
-            x.get("end_week") if x.get("end_week") is not None else float("inf"),
-        ),
-    )
-
-    # Allocate slots
-    slot_allocations = _allocate_slots(sorted_spans)
+    slot_allocations = _allocate_slots(spans)
 
     span_bars = []
     for span in spans:
@@ -318,10 +296,9 @@ def _generate_bars(spans: List[Dict]) -> pd.DataFrame:
             "start_week": start_week,
             "end_date": span.get("end_date"),
             "end_week": end_week,
+            "slot": slot_allocations[entry_idx],
             "tags": span.get("tags", {}),
         }
-
-        slot_info = slot_allocations[entry_idx]
 
         # Create spans for each week in a range when fading is needed
         if start_week is not None and end_week is not None:
@@ -336,34 +313,15 @@ def _generate_bars(spans: List[Dict]) -> pd.DataFrame:
                 duration_slices - duration_in, FADE_WEEKS_IN_PROGRESS * SLICES_PER_WEEK
             )
 
-            if isinstance(slot_info, dict):
-                # Long span with separate slots for fade-out and fade-in
-                if duration_out > 0:
-                    fade_out_template = span_bar_template.copy()
-                    fade_out_template["slot"] = slot_info["fade_out_slot"]
-                    _fade_out_span(
-                        span_bars, fade_out_template, start_week, duration_out
-                    )
-                if duration_in > 0:
-                    fade_in_template = span_bar_template.copy()
-                    fade_in_template["slot"] = slot_info["fade_in_slot"]
-                    _fade_in_span(span_bars, fade_in_template, end_week, duration_in)
-            else:
-                # Short span with single slot
-                span_bar_template["slot"] = slot_info
-                if duration_out > 0:
-                    _fade_out_span(
-                        span_bars, span_bar_template, start_week, duration_out
-                    )
-                if duration_in > 0:
-                    _fade_in_span(span_bars, span_bar_template, end_week, duration_in)
+            if duration_out > 0:
+                _fade_out_span(span_bars, span_bar_template, start_week, duration_out)
+            if duration_in > 0:
+                _fade_in_span(span_bars, span_bar_template, end_week, duration_in)
 
         elif start_week is not None:
-            span_bar_template["slot"] = slot_info
             _fade_out_span(span_bars, span_bar_template, start_week)
 
         else:
-            span_bar_template["slot"] = slot_info
             _fade_in_span(span_bars, span_bar_template, end_week)
 
     bars_df = pd.DataFrame(span_bars)

--- a/app/timeline_data.py
+++ b/app/timeline_data.py
@@ -2,11 +2,14 @@
 This module prepares media entries into spans for the timeline visualization
 """
 
+import logging
 from datetime import datetime, timedelta
 from typing import Dict, List
 
 import numpy as np
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 # Constants for visualization
 # Number of weeks for fade-out gradient for in-progress entries
@@ -17,6 +20,8 @@ MAX_OPACITY = 0.9  # Maximum opacity for bars
 MIN_OPACITY = 0.0  # Minimum opacity for faded bars
 # Number of subslices per week for finer granularity of the opacity gradient
 SLICES_PER_WEEK = 4
+# Maximum number of horizontal slots for the timeline
+MAX_SLOTS = 5
 
 # Color mapping for media types
 MEDIA_TYPE_COLORS = {
@@ -138,6 +143,120 @@ def _fade_in_span(
         )
 
 
+def _allocate_slots(spans: List[Dict]) -> Dict[int, int]:
+    """
+    Allocate horizontal slots for spans to prevent overlapping.
+    
+    Args:
+        spans: List of span dictionaries sorted by start time
+        
+    Returns:
+        Dictionary mapping entry_idx to slot number (0 to MAX_SLOTS-1)
+    """
+    slot_allocations = {}
+    # Track when each slot becomes free (slice index)
+    slot_free_at = [0] * MAX_SLOTS
+    
+    for span in spans:
+        start_week = span.get("start_week")
+        end_week = span.get("end_week")
+        entry_idx = span.get("entry_idx")
+        
+        if start_week is None and end_week is None:
+            continue
+            
+        # Calculate the time range this span will occupy
+        if start_week is not None and end_week is not None:
+            # Full span - occupies from start to end
+            start_slice = start_week * SLICES_PER_WEEK
+            duration_weeks = end_week - start_week + 1
+            duration_slices = duration_weeks * SLICES_PER_WEEK
+            
+            # Check if span is long enough to have a gap between fade-out and fade-in
+            duration_in = min(duration_slices // 2, FADE_WEEKS_FINISH_ONLY * SLICES_PER_WEEK)
+            duration_out = min(duration_slices - duration_in, FADE_WEEKS_IN_PROGRESS * SLICES_PER_WEEK)
+            
+            if duration_out + duration_in < duration_slices:
+                # Long span with gap - can reuse slot for fade-in
+                fade_out_end = start_slice + duration_out
+                fade_in_start = (end_week + 1) * SLICES_PER_WEEK - duration_in
+                
+                # Find slot for fade-out
+                fade_out_slot = None
+                for slot in range(MAX_SLOTS):
+                    if slot_free_at[slot] <= start_slice:
+                        fade_out_slot = slot
+                        slot_free_at[slot] = fade_out_end
+                        break
+                
+                # Find slot for fade-in (can be different)
+                fade_in_slot = None
+                for slot in range(MAX_SLOTS):
+                    if slot_free_at[slot] <= fade_in_start:
+                        fade_in_slot = slot
+                        slot_free_at[slot] = fade_in_start + duration_in
+                        break
+                
+                if fade_out_slot is not None and fade_in_slot is not None:
+                    # Store both slots for this entry
+                    slot_allocations[entry_idx] = {
+                        'fade_out_slot': fade_out_slot,
+                        'fade_in_slot': fade_in_slot
+                    }
+                else:
+                    logger.warning(f"No available slots for span '{span.get('title')}' - skipping")
+            else:
+                # Short span - needs single slot for entire duration
+                end_slice = start_slice + duration_slices
+                slot = None
+                for s in range(MAX_SLOTS):
+                    if slot_free_at[s] <= start_slice:
+                        slot = s
+                        slot_free_at[s] = end_slice
+                        break
+                
+                if slot is not None:
+                    slot_allocations[entry_idx] = slot
+                else:
+                    logger.warning(f"No available slots for span '{span.get('title')}' - skipping")
+                    
+        elif start_week is not None:
+            # In-progress span
+            start_slice = start_week * SLICES_PER_WEEK
+            end_slice = start_slice + FADE_WEEKS_IN_PROGRESS * SLICES_PER_WEEK
+            
+            slot = None
+            for s in range(MAX_SLOTS):
+                if slot_free_at[s] <= start_slice:
+                    slot = s
+                    slot_free_at[s] = end_slice
+                    break
+            
+            if slot is not None:
+                slot_allocations[entry_idx] = slot
+            else:
+                logger.warning(f"No available slots for in-progress span '{span.get('title')}' - skipping")
+                
+        else:
+            # Finish-only span
+            end_slice = (end_week + 1) * SLICES_PER_WEEK
+            start_slice = end_slice - FADE_WEEKS_FINISH_ONLY * SLICES_PER_WEEK
+            
+            slot = None
+            for s in range(MAX_SLOTS):
+                if slot_free_at[s] <= start_slice:
+                    slot = s
+                    slot_free_at[s] = end_slice
+                    break
+            
+            if slot is not None:
+                slot_allocations[entry_idx] = slot
+            else:
+                logger.warning(f"No available slots for finish-only span '{span.get('title')}' - skipping")
+    
+    return slot_allocations
+
+
 def _generate_bars(spans: List[Dict]) -> pd.DataFrame:
     """
     Generate a DataFrame of bars for the timeline visualization.
@@ -145,19 +264,34 @@ def _generate_bars(spans: List[Dict]) -> pd.DataFrame:
         spans: List of dictionaries containing each span of media entry data for the timeline.
     Returns:
         DataFrame with columns: entry_id, title, type, color, start_date, start_week, end_date, end_week,
-            duration_weeks, tags, bar_base, bar_y, & opacity.
+            duration_weeks, tags, bar_base, bar_y, opacity, slot.
     """
+    # Sort spans by start time for slot allocation
+    sorted_spans = sorted(spans, key=lambda x: (
+        x.get("start_week") if x.get("start_week") is not None else x.get("end_week", float('inf')),
+        x.get("end_week") if x.get("end_week") is not None else float('inf')
+    ))
+    
+    # Allocate slots
+    slot_allocations = _allocate_slots(sorted_spans)
+    
     span_bars = []
     for span in spans:
         start_week = span.get("start_week", None)
         end_week = span.get("end_week", None)
+        entry_idx = span.get("entry_idx")
+        
         if start_week is None and end_week is None:
+            continue
+            
+        # Skip if no slot was allocated
+        if entry_idx not in slot_allocations:
             continue
 
         media_type = span.get("type")
         color = MEDIA_TYPE_COLORS.get(media_type, MEDIA_TYPE_COLORS["Unknown"])
         span_bar_template = {
-            "entry_id": span.get("entry_idx"),
+            "entry_id": entry_idx,
             "title": span.get("title"),
             "type": media_type,
             "color": color,
@@ -168,6 +302,8 @@ def _generate_bars(spans: List[Dict]) -> pd.DataFrame:
             "tags": span.get("tags", {}),
         }
 
+        slot_info = slot_allocations[entry_idx]
+        
         # Create spans for each week in a range when fading is needed
         if start_week is not None and end_week is not None:
             duration_weeks = end_week - start_week + 1
@@ -181,15 +317,30 @@ def _generate_bars(spans: List[Dict]) -> pd.DataFrame:
                 duration_slices - duration_in, FADE_WEEKS_IN_PROGRESS * SLICES_PER_WEEK
             )
 
-            if duration_out > 0:
-                _fade_out_span(span_bars, span_bar_template, start_week, duration_out)
-            if duration_in > 0:
-                _fade_in_span(span_bars, span_bar_template, end_week, duration_in)
+            if isinstance(slot_info, dict):
+                # Long span with separate slots for fade-out and fade-in
+                if duration_out > 0:
+                    fade_out_template = span_bar_template.copy()
+                    fade_out_template["slot"] = slot_info['fade_out_slot']
+                    _fade_out_span(span_bars, fade_out_template, start_week, duration_out)
+                if duration_in > 0:
+                    fade_in_template = span_bar_template.copy()
+                    fade_in_template["slot"] = slot_info['fade_in_slot']
+                    _fade_in_span(span_bars, fade_in_template, end_week, duration_in)
+            else:
+                # Short span with single slot
+                span_bar_template["slot"] = slot_info
+                if duration_out > 0:
+                    _fade_out_span(span_bars, span_bar_template, start_week, duration_out)
+                if duration_in > 0:
+                    _fade_in_span(span_bars, span_bar_template, end_week, duration_in)
 
         elif start_week is not None:
+            span_bar_template["slot"] = slot_info
             _fade_out_span(span_bars, span_bar_template, start_week)
 
         else:
+            span_bar_template["slot"] = slot_info
             _fade_in_span(span_bars, span_bar_template, end_week)
 
     bars_df = pd.DataFrame(span_bars)

--- a/app/timeline_data.py
+++ b/app/timeline_data.py
@@ -9,6 +9,8 @@ from typing import Dict, List
 import numpy as np
 import pandas as pd
 
+from app.utils import MAX_SLOTS
+
 logger = logging.getLogger(__name__)
 
 # Constants for visualization
@@ -20,8 +22,6 @@ MAX_OPACITY = 0.9  # Maximum opacity for bars
 MIN_OPACITY = 0.0  # Minimum opacity for faded bars
 # Number of subslices per week for finer granularity of the opacity gradient
 SLICES_PER_WEEK = 4
-# Maximum number of horizontal slots for the timeline
-MAX_SLOTS = 5
 
 # Color mapping for media types
 MEDIA_TYPE_COLORS = {

--- a/app/utils.py
+++ b/app/utils.py
@@ -4,6 +4,9 @@ Utils for handling weeks and dates for preparing the timeline chart.
 
 from datetime import datetime, timedelta
 
+# Maximum number of horizontal slots for the timeline
+MAX_SLOTS = 10
+
 
 def compute_week_index(entry_date: datetime, min_date: datetime) -> int:
     """

--- a/app/utils.py
+++ b/app/utils.py
@@ -3,9 +3,10 @@ Utils for handling weeks and dates for preparing the timeline chart.
 """
 
 from datetime import datetime, timedelta
+import os
 
 # Maximum number of horizontal slots for the timeline
-MAX_SLOTS = 10
+MAX_SLOTS = 20
 
 
 def compute_week_index(entry_date: datetime, min_date: datetime) -> int:
@@ -34,3 +35,13 @@ def get_datetime(date_str: str) -> datetime:
         Datetime object
     """
     return datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=None)
+
+
+def is_debug_mode() -> bool:
+    """
+    Check if the application is running in debug mode.
+
+    Returns:
+        True if in debug mode, False otherwise
+    """
+    return os.getenv("DEBUG", "false").lower() == "true"

--- a/app/utils.py
+++ b/app/utils.py
@@ -5,7 +5,9 @@ Utils for handling weeks and dates for preparing the timeline chart.
 from datetime import datetime, timedelta
 import os
 
-# Maximum number of horizontal slots for the timeline
+# Maximum number of slots along the x-axis for the timeline
+# Increase this value to fit more media entries in a given timeframe,
+# Decrease this to make individual media entries larger on the x-axis
 MAX_SLOTS = 20
 
 

--- a/preprocessing/preprocess.py
+++ b/preprocessing/preprocess.py
@@ -217,7 +217,7 @@ if __name__ == "__main__":
         "preprocessing/raw_data/media_enjoyed.csv",
         "preprocessing/processed_data/media_entries.json",
         start_date=None,
-        end_date="2021-07-01",
+        end_date=None,
     )
 
     # Print statistics

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ plotly==6.1.1
 pydantic==2.11.4
 requests==2.32.3
 streamlit==1.45.1
+watchdog==6.0.0

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -9,12 +9,13 @@ import streamlit as st
 from app.media_entries import load_media_entries, extract_timeline_spans
 from app.timeline_chart import create_timeline_chart
 from app.timeline_data import prepare_timeline_data
+from app.utils import is_debug_mode
 
 
 logger = logging.getLogger(__name__)
 # Configure logging
 logging.basicConfig(
-    level=logging.WARN,
+    level=logging.DEBUG if is_debug_mode() else logging.WARN,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     filename="app/app.log",
     filemode="w",


### PR DESCRIPTION
Introduces a fixed slot allocation system for timeline bars and updates the chart layout to use these slots.
This helps avoid having too wide a chart to fit on screen.

Also controls debug logging & UI element via an environment flag

- Implement _allocate_slots and related helpers in app/timeline_data.py, integrate into _generate_bars
- Update create_timeline_chart in app/timeline_chart.py to position bars by slot, adjust layout parameters
- Extend tests to cover slot allocation and slot presence in generated bars
- Add is_debug_mode() in app/utils.py to control debug logging and slot count
- Add debug-start target to Makefile 
- Tweak the Streamlit theme config