### PR TITLE
Add images to items on the timeline

### DIFF
--- a/app/tests/test_timeline_data.py
+++ b/app/tests/test_timeline_data.py
@@ -395,7 +395,7 @@ def test_allocate_slots_overflow(caplog):
 def test_allocate_slots_long_span_reuse():
     """Test that long spans can reuse slots for fade-in after fade-out."""
     with patch("app.timeline_data.MAX_SLOTS", 1):
-        long_duration = FADE_WEEKS_IN_PROGRESS + FADE_WEEKS_FINISH_ONLY + 2
+        long_duration = FADE_WEEKS_IN_PROGRESS * 3
         spans = [
             {
                 "entry_idx": 0,

--- a/app/timeline_chart.py
+++ b/app/timeline_chart.py
@@ -21,7 +21,7 @@ MIN_CHART_HEIGHT = 480
 
 
 def _add_bar(
-    fig: go.Figure, poster_images: list, posters_added: set, next_bar: pd.Series
+    fig: go.Figure, poster_images: list, posters_added: set, bar_data: pd.Series
 ):
     """
     Add a single bar to the Plotly figure.
@@ -29,35 +29,35 @@ def _add_bar(
         fig: Plotly figure to add the bar to
         poster_images: List to store poster image data
         posters_added: Set to track unique poster paths
-        next_bar: Series containing bar data
+        bar_data: Series containing bar data
     """
     rgba_tuple = tuple(
-        int(next_bar["color"].lstrip("#")[i : (i + 2)], 16) for i in (0, 2, 4)
-    ) + (next_bar["opacity"],)
+        int(bar_data["color"].lstrip("#")[i : (i + 2)], 16) for i in (0, 2, 4)
+    ) + (bar_data["opacity"],)
 
-    tooltip_list = [f"{next_bar['title']} ({next_bar['type']})"]
-    if not np.isnan(next_bar["start_week"]):
+    tooltip_list = [f"{bar_data['title']} ({bar_data['type']})"]
+    if not np.isnan(bar_data["start_week"]):
         tooltip_list.append(
-            f"Start: {next_bar['start_date']} ({next_bar['start_week']:.0f})"
+            f"Start: {bar_data['start_date']} ({bar_data['start_week']:.0f})"
         )
-    if not np.isnan(next_bar["end_week"]):
+    if not np.isnan(bar_data["end_week"]):
         tooltip_list.append(
-            f"Finish: {next_bar['end_date']} ({next_bar['end_week']:.0f})"
+            f"Finish: {bar_data['end_date']} ({bar_data['end_week']:.0f})"
         )
-    if not np.isnan(next_bar["duration_weeks"]):
-        tooltip_list.append(f"Duration: {next_bar['duration_weeks']:.0f} week(s)")
+    if not np.isnan(bar_data["duration_weeks"]):
+        tooltip_list.append(f"Duration: {bar_data['duration_weeks']:.0f} week(s)")
     tooltip = "<br>".join(tooltip_list)
 
     extra_spacing = (BAR_WIDTH - BAR_SPACING) * (
-        math.pow(1 - next_bar["opacity"], 2) / 12
+        math.pow(1 - bar_data["opacity"], 2) / 12
     )
 
-    x = next_bar["slot"] * BAR_WIDTH + BAR_SPACING + extra_spacing
-    y_base = next_bar["bar_base"]
+    x = bar_data["slot"] * BAR_WIDTH + BAR_SPACING + extra_spacing
+    y_base = bar_data["bar_base"]
     fig.add_trace(
         go.Bar(
             x=[x],
-            y=[next_bar["bar_y"]],
+            y=[bar_data["bar_y"]],
             base=[y_base],
             orientation="v",
             marker_color=f"rgba{rgba_tuple}",
@@ -69,8 +69,8 @@ def _add_bar(
         )
     )
 
-    entry_id = next_bar["entry_id"]
-    poster_path = next_bar.get("poster_path")
+    entry_id = bar_data["entry_id"]
+    poster_path = bar_data.get("poster_path")
     if poster_path and entry_id not in posters_added:
         image_width = BAR_WIDTH - BAR_SPACING
         poster_images.append(

--- a/app/timeline_chart.py
+++ b/app/timeline_chart.py
@@ -15,9 +15,78 @@ logger = logging.getLogger(__name__)
 
 BAR_WIDTH = 1.0
 BAR_SPACING = 0.05  # Spacing between bars on the x-axis
-HEIGHT_FACTOR = 4  # Increase this to stretch the chart vertically
+HEIGHT_FACTOR = 8  # Increase this to stretch the chart vertically
 IMAGE_Y_OFFSET = 0.5
 MIN_CHART_HEIGHT = 480
+
+
+def _add_bar(
+    fig: go.Figure, poster_images: list, posters_added: set, next_bar: pd.Series
+):
+    """
+    Add a single bar to the Plotly figure.
+    Args:
+        fig: Plotly figure to add the bar to
+        poster_images: List to store poster image data
+        posters_added: Set to track unique poster paths
+        next_bar: Series containing bar data
+    """
+    rgba_tuple = tuple(
+        int(next_bar["color"].lstrip("#")[i : (i + 2)], 16) for i in (0, 2, 4)
+    ) + (next_bar["opacity"],)
+
+    tooltip_list = [f"{next_bar['title']} ({next_bar['type']})"]
+    if not np.isnan(next_bar["start_week"]):
+        tooltip_list.append(
+            f"Start: {next_bar['start_date']} ({next_bar['start_week']:.0f})"
+        )
+    if not np.isnan(next_bar["end_week"]):
+        tooltip_list.append(
+            f"Finish: {next_bar['end_date']} ({next_bar['end_week']:.0f})"
+        )
+    if not np.isnan(next_bar["duration_weeks"]):
+        tooltip_list.append(f"Duration: {next_bar['duration_weeks']:.0f} week(s)")
+    tooltip = "<br>".join(tooltip_list)
+
+    extra_spacing = (BAR_WIDTH - BAR_SPACING) * (
+        math.pow(1 - next_bar["opacity"], 2) / 12
+    )
+
+    x = next_bar["slot"] * BAR_WIDTH + BAR_SPACING + extra_spacing
+    y_base = next_bar["bar_base"]
+    fig.add_trace(
+        go.Bar(
+            x=[x],
+            y=[next_bar["bar_y"]],
+            base=[y_base],
+            orientation="v",
+            marker_color=f"rgba{rgba_tuple}",
+            width=BAR_WIDTH - BAR_SPACING - 2 * extra_spacing,
+            hovertemplate=tooltip,
+            showlegend=False,
+            offsetgroup=1,
+            offset=0,
+        )
+    )
+
+    entry_id = next_bar["entry_id"]
+    poster_path = next_bar.get("poster_path")
+    if poster_path and entry_id not in posters_added:
+        image_width = BAR_WIDTH - BAR_SPACING
+        poster_images.append(
+            {
+                "source": poster_path,
+                "xref": "x",
+                "yref": "y",
+                "x": x + image_width / 8 - extra_spacing,
+                "y": y_base + IMAGE_Y_OFFSET,
+                "sizing": "contain",
+                "sizex": image_width * 3 / 4,
+                "sizey": 1000,  # A large number so the width does the constraining
+                "layer": "above",
+            }
+        )
+        posters_added.add(entry_id)
 
 
 def create_timeline_chart(weeks_df: pd.DataFrame, bars_df: pd.DataFrame) -> go.Figure:
@@ -56,62 +125,9 @@ def create_timeline_chart(weeks_df: pd.DataFrame, bars_df: pd.DataFrame) -> go.F
 
     # Add bars for entries
     poster_images = []
-    poster_added = set()  # To track unique poster paths
+    posters_added = set()  # To track unique poster paths
     for _, next_bar in bars_df.iterrows():
-        rgba_tuple = tuple(
-            int(next_bar["color"].lstrip("#")[i : (i + 2)], 16) for i in (0, 2, 4)
-        ) + (next_bar["opacity"],)
-
-        tooltip_list = [f"{next_bar['title']} ({next_bar['type']})"]
-        if not np.isnan(next_bar["start_week"]):
-            tooltip_list.append(
-                f"Start: {next_bar['start_date']} ({next_bar['start_week']:.0f})"
-            )
-        if not np.isnan(next_bar["end_week"]):
-            tooltip_list.append(
-                f"Finish: {next_bar['end_date']} ({next_bar['end_week']:.0f})"
-            )
-        if not np.isnan(next_bar["duration_weeks"]):
-            tooltip_list.append(f"Duration: {next_bar['duration_weeks']:.0f} week(s)")
-        tooltip = "<br>".join(tooltip_list)
-
-        extra_spacing = (BAR_WIDTH - BAR_SPACING) * (
-            math.pow(1 - next_bar["opacity"], 2) / 12
-        )
-
-        x = next_bar["slot"] * BAR_WIDTH + BAR_SPACING + extra_spacing
-        y_base = next_bar["bar_base"]
-        fig.add_trace(
-            go.Bar(
-                x=[x],
-                y=[next_bar["bar_y"]],
-                base=[y_base],
-                orientation="v",
-                marker_color=f"rgba{rgba_tuple}",
-                width=BAR_WIDTH - BAR_SPACING - 2 * extra_spacing,
-                hovertemplate=tooltip,
-                showlegend=False,
-                offsetgroup=1,
-                offset=0,
-            )
-        )
-
-        entry_id = next_bar["entry_id"]
-        poster_path = next_bar.get("poster_path")
-        if poster_path and entry_id not in poster_added:
-            image_width = (BAR_WIDTH - BAR_SPACING)
-            poster_images.append({
-                "source": poster_path,
-                "xref": "x",
-                "yref": "y",
-                "x": x + image_width / 8,
-                "y": y_base + IMAGE_Y_OFFSET,
-                "sizing": "contain",
-                "sizex": image_width * 3 / 4,
-                "sizey": 1000,  # A large number so the width does the constraining
-                "layer": "above",
-            })
-            poster_added.add(entry_id)
+        _add_bar(fig, poster_images, posters_added, next_bar)
 
     # Drop tick text if same as prior week
     # Since the tick text is the name of the month, this means we just show each month name once

--- a/app/timeline_data.py
+++ b/app/timeline_data.py
@@ -328,6 +328,7 @@ def _generate_bars(spans: List[Dict]) -> pd.DataFrame:
             "end_week": end_week,
             "slot": slot_allocations[entry_idx],
             "tags": span.get("tags", {}),
+            "poster_path": span.get("poster_path"),
         }
 
         # Create spans for each week in a range when fading is needed

--- a/app/timeline_data.py
+++ b/app/timeline_data.py
@@ -208,7 +208,8 @@ def _allocate_slot_to_span(
     next_future_block = None
     if free_week - start_week > FADE_WEEKS_IN_PROGRESS + FADE_WEEKS_FINISH_ONLY:
         next_future_block = {
-            "start_slice": (free_week - FADE_WEEKS_FINISH_ONLY) * SLICES_PER_WEEK,
+            "start_slice": (free_week - FADE_WEEKS_FINISH_ONLY - VERTICAL_SPACING_WEEKS)
+            * SLICES_PER_WEEK,
             "free_slice": free_slice,
             "entry_idx": entry_idx,
         }
@@ -347,6 +348,9 @@ def _generate_bars(spans: List[Dict]) -> pd.DataFrame:
             if duration_out > 0:
                 _fade_out_span(span_bars, span_bar_template, start_week, duration_out)
             if duration_in > 0:
+                # Modify the entry_idx so we show the poster again if the duration is long enough
+                if duration_weeks > FADE_WEEKS_IN_PROGRESS * 3:
+                    span_bar_template["entry_id"] = f"{entry_idx} (end)"
                 _fade_in_span(span_bars, span_bar_template, end_week, duration_in)
 
         elif start_week is not None:

--- a/app/timeline_data.py
+++ b/app/timeline_data.py
@@ -208,8 +208,10 @@ def _allocate_slot_to_span(
     next_future_block = None
     if free_week - start_week > FADE_WEEKS_IN_PROGRESS + FADE_WEEKS_FINISH_ONLY:
         next_future_block = {
-            "start_slice": (free_week - FADE_WEEKS_FINISH_ONLY - VERTICAL_SPACING_WEEKS)
-            * SLICES_PER_WEEK,
+            "start_slice": (
+                (free_week - FADE_WEEKS_FINISH_ONLY - VERTICAL_SPACING_WEEKS)
+                * SLICES_PER_WEEK
+            ),
             "free_slice": free_slice,
             "entry_idx": entry_idx,
         }
@@ -292,6 +294,34 @@ def _allocate_slots(spans: List[Dict]) -> Dict[int, int]:
     return slot_allocations
 
 
+def _create_bar_template_from_span(
+    slot_allocations: Dict[int, int], span: Dict
+) -> Dict:
+    """
+    Create a template dictionary for a span bar from the given span data.
+    Args:
+        slot_allocations: Dictionary mapping entry_idx to slot number
+        span: Dictionary containing span data
+    Returns:
+        Template dictionary with keys: entry_id, title, type, color, start_date,
+            start_week, end_date, end_week, tags, poster_path.
+    """
+    entry_idx = span.get("entry_idx")
+    return {
+        "entry_id": entry_idx,
+        "title": span.get("title"),
+        "type": span.get("type"),
+        "color": MEDIA_TYPE_COLORS.get(span.get("type"), MEDIA_TYPE_COLORS["Unknown"]),
+        "start_date": span.get("start_date"),
+        "start_week": span.get("start_week"),
+        "end_date": span.get("end_date"),
+        "end_week": span.get("end_week"),
+        "tags": span.get("tags", {}),
+        "slot": slot_allocations[entry_idx],
+        "poster_path": span.get("poster_path"),
+    }
+
+
 def _generate_bars(spans: List[Dict]) -> pd.DataFrame:
     """
     Generate a DataFrame of bars for the timeline visualization.
@@ -316,23 +346,8 @@ def _generate_bars(spans: List[Dict]) -> pd.DataFrame:
         if entry_idx not in slot_allocations:
             continue
 
-        media_type = span.get("type")
-        color = MEDIA_TYPE_COLORS.get(media_type, MEDIA_TYPE_COLORS["Unknown"])
-        span_bar_template = {
-            "entry_id": entry_idx,
-            "title": span.get("title"),
-            "type": media_type,
-            "color": color,
-            "start_date": span.get("start_date"),
-            "start_week": start_week,
-            "end_date": span.get("end_date"),
-            "end_week": end_week,
-            "slot": slot_allocations[entry_idx],
-            "tags": span.get("tags", {}),
-            "poster_path": span.get("poster_path"),
-        }
-
         # Create spans for each week in a range when fading is needed
+        span_bar_template = _create_bar_template_from_span(slot_allocations, span)
         if start_week is not None and end_week is not None:
             duration_weeks = end_week - start_week + 1
             span_bar_template["duration_weeks"] = duration_weeks
@@ -349,9 +364,10 @@ def _generate_bars(spans: List[Dict]) -> pd.DataFrame:
                 _fade_out_span(span_bars, span_bar_template, start_week, duration_out)
             if duration_in > 0:
                 # Modify the entry_idx so we show the poster again if the duration is long enough
+                span_bar_copy = span_bar_template.copy()
                 if duration_weeks > FADE_WEEKS_IN_PROGRESS * 3:
-                    span_bar_template["entry_id"] = f"{entry_idx} (end)"
-                _fade_in_span(span_bars, span_bar_template, end_week, duration_in)
+                    span_bar_copy["entry_id"] = f"{entry_idx} (end)"
+                _fade_in_span(span_bars, span_bar_copy, end_week, duration_in)
 
         elif start_week is not None:
             _fade_out_span(span_bars, span_bar_template, start_week)


### PR DESCRIPTION
Adds poster images to timeline entries and refines bar positioning and slot allocation

- Includes poster_path in data spans and re-shows posters after long durations
- Collects images from data spans and overlays them on the figure
- Refactors chart code to _add_bar
- Adjusts slot allocation to better ensure vertical spacing gaps