### PR TITLE
Add additional hints.  Also add the ability to match a title to separate media based on the date.

### DIFF
--- a/preprocessing/hints.yaml
+++ b/preprocessing/hints.yaml
@@ -12,13 +12,46 @@
 BioShock:
   canonical_title: "BioShock"
   type: "Game"
+  release_year: "2007"
+
+Black Widow:
+  canonical_title: "Black Widow"
+  type: "Game"
+  release_year: "1983"
+
+Die Hard:
+  canonical_title: "Die Hard"
+  type: "Game"
+  release_year: "1989"
+
+Endgame:
+  canonical_title: "Endgame"
+  type: "Game"
+  release_year: "2002"
 
 FF7:
   canonical_title: "Final Fantasy VII Remake"
   type: "Game"
 
 Hades:
+  canonical_title: "Hades"
   type: "Game"
+  release_year: "2020"
+
+Kate:
+  canonical_title: "Kate"
+  type: "Game"
+  release_year: "2023"
+
+Prey:
+  canonical_title: "Prey"
+  type: "Game"
+  release_year: "2017"
+
+Superman:
+  canonical_title: "Superman"
+  type: "Game"
+  release_year: "1992"
 
 The Avengers:
   canonical_title: "Marvel's Avengers"
@@ -28,15 +61,170 @@ The Avengers w/ Danyi:
   canonical_title: "Marvel's Avengers"
   type: "Game"
 
+Top Gun:
+  canonical_title: "Top Gun"
+  type: "Game"
+  release_year: "1987"
+
+Zodiac:
+  canonical_title: "Zodiac"
+  type: "Game"
+  release_year: "2021"
+
 # Books
+Abaddon's Gate:
+  canonical_title: "Abaddon's Gate"
+  type: "Book"
+  release_year: "2013"
+
+Be Prepared:
+  canonical_title: "Be Prepared"
+  type: "Book"
+  release_year: "2018"
+
+Blood of Elves:
+  canonical_title: "Blood of Elves"
+  type: "Book"
+  release_year: "2009"
+
+Caliban's War:
+  canonical_title: "Caliban's war"
+  type: "Book"
+  release_year: "2012"
+
+Data Mesh:
+  canonical_title: "Data Mesh"
+  type: "Book"
+  release_year: "2022"
+
+Don Quixote:
+  canonical_title: "Don Quixote"
+  type: "Book"
+  release_year: "1600"
+
+Hamilton:
+  canonical_title: "Hamilton"
+  type: "Book"
+  release_year: "2016"
+
+Hidden Brain:
+  canonical_title: "The hidden brain"
+  type: "Book"
+  release_year: "2009"
+
+Losers:
+  canonical_title: "Losers"
+  type: "Book"
+  release_year: "2022"
+
+Midnight Mass:
+  canonical_title: "Midnight Mass"
+  type: "Book"
+  release_year: "2005"
+
+Off the Clock:
+  canonical_title: "Off the clock"
+  type: "Book"
+  release_year: "2018"
+
+Pieces of Her:
+  canonical_title: "Pieces of Her"
+  type: "Book"
+  release_year: "2018"
+
+Radical Candor:
+  canonical_title: "Radical Candor"
+  type: "Book"
+  release_year: "2017"
+
 Sapiens:
   type: "Book"
   release_year: "2011"
 
+Soon I Will Be Invincible:
+  canonical_title: "Soon I Will Be Invincible"
+  type: "Book"
+  release_year: "2007"
+
+Super Pumped:
+  canonical_title: "Super Pumped"
+  type: "Book"
+  release_year: "2019"
+
+Sword of Destiny:
+  canonical_title: "Sword of Destiny"
+  type: "Book"
+  release_year: "2015"
+
+The Harder They Fall:
+  canonical_title: "The harder they fall"
+  type: "Book"
+  release_year: "1947"
+
+The King's Man:
+  canonical_title: "The King's Man"
+  type: "Book"
+  release_year: "2007"
+
+The Library of Babel:
+  canonical_title: "The Library of Babel"
+  type: "Book"
+  release_year: "1991"
+
+The Phantom Menace:
+  canonical_title: "The Phantom Menace"
+  type: "Book"
+  release_year: "1999"
+
+Thinking Fast:
+  canonical_title: "Thinking, fast and slow"
+  type: "Book"
+  release_year: "2011"
+
+Tombstone:
+  canonical_title: "Tombstone"
+  type: "Book"
+  release_year: "2020"
+
+We Own This City:
+  canonical_title: "We Own This City"
+  type: "Book"
+  release_year: "2021"
+
 # TV Shows
+Archer S1:
+  canonical_title: "Archer"
+  type: "TV Show"
+  release_year: "2009"
+
+Archer S10:
+  canonical_title: "Archer"
+  type: "TV Show"
+  release_year: "2009"
+
+Big Sky S1:
+  canonical_title: "Big Sky"
+  type: "TV Show"
+  release_year: "2020"
+
 Captain Falcon & the Winter Soldier:
   canonical_title: "The Falcon and the Winter Soldier"
   type: "TV Show"
+
+Dark Matter S1:
+  canonical_title: "Dark Matter"
+  type: "TV Show"
+  release_year: "2015"
+
+Dark Matter S2:
+  canonical_title: "Dark Matter"
+  type: "TV Show"
+  release_year: "2015"
+
+Dark Matter S3:
+  canonical_title: "Dark Matter"
+  type: "TV Show"
+  release_year: "2015"
 
 Falcon & Winter Soldier:
   canonical_title: "The Falcon and the Winter Soldier"
@@ -46,19 +234,49 @@ Finished WandaVision:
   canonical_title: "WandaVision"
   type: "TV Show"
 
+Goliath S4:
+  canonical_title: "Goliath"
+  type: "TV Show"
+  release_year: "2016"
+
 Loki:
   type: "TV Show"
 
+Lost in Space S3:
+  canonical_title: "Lost in Space"
+  type: "TV Show"
+  release_year: "2018"
+
 Love, Death, & Robots:
   type: "TV Show"
+
+Lupin S1:
+  canonical_title: "Lupin"
+  type: "TV Show"
+  release_year: "2021"
+
+MODOK S1:
+  canonical_title: "Marvel's M.O.D.O.K."
+  type: "TV Show"
+  release_year: "2021"
 
 Nevers:
   canonical_title: "The Nevers"
   type: "TV Show"
 
+Search Party S1:
+  canonical_title: "Search Party"
+  type: "TV Show"
+  release_year: "2016"
+
 Shadow & Bone:
   canonical_title: "Shadow and Bone"
   type: "TV Show"
+
+Sisyphus S1:
+  canonical_title: "Sisyphus"
+  type: "TV Show"
+  release_year: "2021"
 
 Snowpiercer:
   type: "TV Show"
@@ -67,10 +285,180 @@ Star Trek Discovery:
   canonical_title: "Star Trek: Discovery"
   type: "TV Show"
 
+Startup S1:
+  canonical_title: "StartUp"
+  type: "TV Show"
+  release_year: "2016"
+
+The Last Kingdom:
+  canonical_title: "The Last Kingdom"
+  type: "TV Show"
+  release_year: "2015"
+
+The Witcher S1:
+  canonical_title: "The Witcher"
+  type: "TV Show"
+  release_year: "2019"
+
+The Witcher S2:
+  canonical_title: "The Witcher"
+  type: "TV Show"
+  release_year: "2019"
+
+Unnatural Selection S1:
+  canonical_title: "Unnatural Selection"
+  type: "TV Show"
+  release_year: "2019"
+
+X-Men s2:
+  canonical_title: "X-Men"
+  type: "TV Show"
+  release_year: "1992"
+
 # Movies
+3:10 to Yuma:
+  canonical_title: "3:10 to Yuma"
+  type: "Movie"
+  release_year: "2007"
+
+Barry:
+  canonical_title: "Barry"
+  type: "Movie"
+  release_year: "2016"
+
+Black Monday:
+  canonical_title: "Black Monday"
+  type: "Movie"
+  release_year: "1988"
+
+Cowboy Bebop:
+  canonical_title: "Cowboy Bebop"
+  type: "Movie"
+  release_year: "2001"
+
+Fargo:
+  canonical_title: "Fargo"
+  type: "Movie"
+  release_year: "1996"
+
+Gentleman Jack:
+  canonical_title: "Gentleman Jack"
+  type: "Movie"
+  release_year: "1999"
+
+Jungle Cruise:
+  canonical_title: "Jungle Cruise"
+  type: "Movie"
+  release_year: "2021"
+
+Lois:
+  canonical_title: "Lois"
+  type: "Movie"
+  release_year: "2012"
+
+Moon Knight:
+  canonical_title: "Moon Knight"
+  type: "Movie"
+  release_year: "2009"
+
 Mortal Combat:
   canonical_title: "Mortal Kombat"
   type: "Movie"
+
+Nobody:
+  canonical_title: "Nobody"
+  type: "Movie"
+  release_year: "2021"
+
+No Time to Die:
+  canonical_title: "No Time to Die"
+  type: "Movie"
+  release_year: "2021"
+
+Only Murders in the Building:
+  canonical_title: "Only Murders in the Building"
+  type: "Movie"
+  release_year: "2021"
+
+Players:
+  canonical_title: "Players"
+  type: "Movie"
+  release_year: "2024"
+
+Porco Rosso:
+  canonical_title: "Porco Rosso"
+  type: "Movie"
+  release_year: "1992"
+
+Raising Arizona:
+  canonical_title: "Raising Arizona"
+  type: "Movie"
+  release_year: "1987"
+
+Six Feet Under:
+  canonical_title: "Six Feet Under"
+  type: "Movie"
+  release_year: "2023"
+
+Slow:
+  canonical_title: "Slow"
+  type: "Movie"
+  release_year: "2021"
+
+Spider-Man: No Way Home:
+  canonical_title: "Spider-Man: No Way Home"
+  type: "Movie"
+  release_year: "2021"
+
+Star Trek: Strange New Worlds:
+  canonical_title: "Star Trek: Strange New Worlds"
+  type: "Movie"
+  release_year: "2022"
+
+Tenet:
+  canonical_title: "Tenet"
+  type: "Movie"
+  release_year: "2020"
+
+The Batman:
+  canonical_title: "The Batman"
+  type: "Movie"
+  release_year: "2022"
+
+The Big Lebowski:
+  canonical_title: "The Big Lebowski"
+  type: "Movie"
+  release_year: "1998"
+
+The Eternals:
+  canonical_title: "The Eternals"
+  type: "Movie"
+  release_year: "2017"
+
+The Master:
+  canonical_title: "The Master"
+  type: "Movie"
+  release_year: "2012"
+
+The Old Man:
+  canonical_title: "The Old Man"
+  type: "Movie"
+  release_year: "2019"
+
+Uncharted:
+  canonical_title: "Uncharted"
+  type: "Movie"
+  release_year: "2022"
+
+We Own this City:
+  canonical_title: "We Own This City"
+  type: "Movie"
+  release_year: "2022"
+
+Yellowjackets:
+  canonical_title: "Yellowjackets"
+  type: "Movie"
+  release_year: "2021"
 
 # Other
 Ant Design:

--- a/preprocessing/hints.yaml
+++ b/preprocessing/hints.yaml
@@ -92,24 +92,19 @@ The Library of Babel:
   type: "Book"
   release_year: "1991"
 
-Thinking Fast:
-  canonical_title: "Thinking, fast and slow"
+Thinking Fast & Slow:
+  canonical_title: "Thinking, Fast and Slow"
   type: "Book"
   release_year: "2011"
 
 
 # TV Shows
-Archer S1:
+Archer:
   canonical_title: "Archer"
   type: "TV Show"
   release_year: "2009"
 
-Archer S10:
-  canonical_title: "Archer"
-  type: "TV Show"
-  release_year: "2009"
-
-Big Sky S1:
+Big Sky:
   canonical_title: "Big Sky"
   type: "TV Show"
   release_year: "2020"
@@ -118,17 +113,7 @@ Captain Falcon & the Winter Soldier:
   canonical_title: "The Falcon and the Winter Soldier"
   type: "TV Show"
 
-Dark Matter S1:
-  canonical_title: "Dark Matter"
-  type: "TV Show"
-  release_year: "2015"
-
-Dark Matter S2:
-  canonical_title: "Dark Matter"
-  type: "TV Show"
-  release_year: "2015"
-
-Dark Matter S3:
+Dark Matter:
   canonical_title: "Dark Matter"
   type: "TV Show"
   release_year: "2015"
@@ -141,7 +126,7 @@ Finished WandaVision:
   canonical_title: "WandaVision"
   type: "TV Show"
 
-Goliath S4:
+Goliath:
   canonical_title: "Goliath"
   type: "TV Show"
   release_year: "2016"
@@ -157,12 +142,12 @@ Lost in Space S3:
 Love, Death, & Robots:
   type: "TV Show"
 
-Lupin S1:
+Lupin:
   canonical_title: "Lupin"
   type: "TV Show"
   release_year: "2021"
 
-MODOK S1:
+MODOK:
   canonical_title: "Marvel's M.O.D.O.K."
   type: "TV Show"
   release_year: "2021"
@@ -171,7 +156,7 @@ Nevers:
   canonical_title: "The Nevers"
   type: "TV Show"
 
-Search Party S1:
+Search Party:
   canonical_title: "Search Party"
   type: "TV Show"
   release_year: "2016"
@@ -180,7 +165,7 @@ Shadow & Bone:
   canonical_title: "Shadow and Bone"
   type: "TV Show"
 
-Sisyphus S1:
+Sisyphus:
   canonical_title: "Sisyphus"
   type: "TV Show"
   release_year: "2021"
@@ -188,11 +173,16 @@ Sisyphus S1:
 Snowpiercer:
   type: "TV Show"
 
+"Star Trek: Strange New Worlds":
+  canonical_title: "Star Trek: Strange New Worlds"
+  type: "TV Show"
+  release_year: "2022"
+
 Star Trek Discovery:
   canonical_title: "Star Trek: Discovery"
   type: "TV Show"
 
-Startup S1:
+Startup:
   canonical_title: "StartUp"
   type: "TV Show"
   release_year: "2016"
@@ -200,28 +190,24 @@ Startup S1:
 Superman & Lois:
   canonical_title: "Superman & Lois"
   type: "TV Show"
+  release_year: "2021"
 
 The Last Kingdom:
   canonical_title: "The Last Kingdom"
   type: "TV Show"
   release_year: "2015"
 
-The Witcher S1:
+The Witcher:
   canonical_title: "The Witcher"
   type: "TV Show"
   release_year: "2019"
 
-The Witcher S2:
-  canonical_title: "The Witcher"
-  type: "TV Show"
-  release_year: "2019"
-
-Unnatural Selection S1:
+Unnatural Selection:
   canonical_title: "Unnatural Selection"
   type: "TV Show"
   release_year: "2019"
 
-X-Men s2:
+X-Men:
   canonical_title: "X-Men"
   type: "TV Show"
   release_year: "1992"
@@ -301,20 +287,10 @@ Raising Arizona:
   type: "Movie"
   release_year: "1987"
 
-Slow:
-  canonical_title: "Slow"
-  type: "Movie"
-  release_year: "2021"
-
-Spider-Man: No Way Home:
+"Spider-Man: No Way Home":
   canonical_title: "Spider-Man: No Way Home"
   type: "Movie"
   release_year: "2021"
-
-Star Trek: Strange New Worlds:
-  canonical_title: "Star Trek: Strange New Worlds"
-  type: "Movie"
-  release_year: "2022"
 
 Tenet:
   canonical_title: "Tenet"
@@ -377,23 +353,23 @@ Zodiac:
   release_year: "2007"
 
 # Other
+Accessibility UX study:
+  type: "Ignored"
 Ant Design:
   type: "Ignored"
 BackstopJS:
   type: "Ignored"
-React Native Paper:
-  type: "Ignored"
-Todo App testing:
-  type: "Ignored"
-Accessibility UX study:
-  type: "Ignored"
 Bald Move - Fargo:
-  type: "Ignored"
-MSF Doom Raids:
-  type: "Ignored"
-MSF DD4 (run 1):
   type: "Ignored"
 Hidden Brain:
   type: "Ignored"
+MSF DD4 (run 1):
+  type: "Ignored"
+MSF Doom Raids:
+  type: "Ignored"
 Off the Clock:
+  type: "Ignored"
+React Native Paper:
+  type: "Ignored"
+Todo App testing:
   type: "Ignored"

--- a/preprocessing/hints.yaml
+++ b/preprocessing/hints.yaml
@@ -28,10 +28,6 @@ Prey:
   type: "Game"
   release_year: "2017"
 
-Superman:
-  canonical_title: "Superman"
-  type: "Game"
-  release_year: "1992"
 
 The Avengers:
   canonical_title: "Marvel's Avengers"

--- a/preprocessing/hints.yaml
+++ b/preprocessing/hints.yaml
@@ -50,7 +50,7 @@ Abaddon's Gate:
 Be Prepared:
   canonical_title: "Be Prepared: A Practical Handbook for New Dads"
   type: "Book"
-  release_year: "2018"
+  release_year: "2004"
 
 Blood of Elves:
   canonical_title: "Blood of Elves"

--- a/preprocessing/hints.yaml
+++ b/preprocessing/hints.yaml
@@ -197,6 +197,10 @@ Startup S1:
   type: "TV Show"
   release_year: "2016"
 
+Superman & Lois:
+  canonical_title: "Superman & Lois"
+  type: "TV Show"
+
 The Last Kingdom:
   canonical_title: "The Last Kingdom"
   type: "TV Show"

--- a/preprocessing/hints.yaml
+++ b/preprocessing/hints.yaml
@@ -366,21 +366,32 @@ Todo App testing:
 
 # Multi-matches
 Dark Matter:
-  - canonical_title: "Dark Matter"
-    type: "TV Show"
-    release_year: "2015"
-    week: "Aug 10-16"
-  - canonical_title: "Dark Matter"
-    type: "TV Show"
-    release_year: "2024"
-    week: "Sep 10-16"
+- canonical_title: "Dark Matter"
+  type: "TV Show"
+  release_year: "2015"
+  dates:
+  - "2021-08-16"
+  - "2021-08-30"
+  - "2021-10-18"
+- canonical_title: "Dark Matter"
+  type: "TV Show"
+  release_year: "2024"
+  dates:
+  - "2024-05-06"
+  - "2024-06-24"
 
 Fargo:
-  - canonical_title: "Fargo"
-    type: "Movie"
-    release_year: "1996"
-    week: "Sept 13-19"
-  - canonical_title: "Fargo"
-    type: "TV Show"
-    release_year: "2014"
-    week: "Jan 13-19"
+- canonical_title: "Fargo"
+  type: "Movie"
+  release_year: "1996"
+  dates:
+  - "2021-09-13"
+- canonical_title: "Fargo"
+  type: "TV Show"
+  release_year: "2014"
+  dates:
+  - "2021-06-21"
+  - "2021-07-26"
+  - "2021-09-13"
+  - "2021-11-01"
+  - "2024-01-22"

--- a/preprocessing/hints.yaml
+++ b/preprocessing/hints.yaml
@@ -113,11 +113,6 @@ Captain Falcon & the Winter Soldier:
   canonical_title: "The Falcon and the Winter Soldier"
   type: "TV Show"
 
-Dark Matter:
-  canonical_title: "Dark Matter"
-  type: "TV Show"
-  release_year: "2015"
-
 Falcon & Winter Soldier:
   canonical_title: "The Falcon and the Winter Soldier"
   type: "TV Show"
@@ -134,7 +129,7 @@ Goliath:
 Loki:
   type: "TV Show"
 
-Lost in Space S3:
+Lost in Space:
   canonical_title: "Lost in Space"
   type: "TV Show"
   release_year: "2018"
@@ -212,13 +207,6 @@ X-Men:
   type: "TV Show"
   release_year: "1992"
 
-# Week-specific entries for disambiguation  
-X-Men:
-  canonical_title: "X-Men"
-  type: "Movie"
-  release_year: "2000"
-  week: 200  # Example week number for movie
-
 # Movies
 3:10 to Yuma:
   canonical_title: "3:10 to Yuma"
@@ -239,18 +227,6 @@ Endgame:
   canonical_title: "Avengers: Endgame"
   type: "Movie"
   release_year: "2019"
-
-Fargo:
-  canonical_title: "Fargo"
-  type: "Movie"
-  release_year: "1996"
-
-# Week-specific entries for disambiguation
-Fargo:
-  canonical_title: "Fargo"
-  type: "TV Show"
-  release_year: "2014"
-  week: 150  # Example week number for TV show
 
 Hamilton:
   canonical_title: "Hamilton"
@@ -387,3 +363,24 @@ React Native Paper:
   type: "Ignored"
 Todo App testing:
   type: "Ignored"
+
+# Multi-matches
+Dark Matter:
+  - canonical_title: "Dark Matter"
+    type: "TV Show"
+    release_year: "2015"
+    week: "Aug 10-16"
+  - canonical_title: "Dark Matter"
+    type: "TV Show"
+    release_year: "2024"
+    week: "Sep 10-16"
+
+Fargo:
+  - canonical_title: "Fargo"
+    type: "Movie"
+    release_year: "1996"
+    week: "Sept 13-19"
+  - canonical_title: "Fargo"
+    type: "TV Show"
+    release_year: "2014"
+    week: "Jan 13-19"

--- a/preprocessing/hints.yaml
+++ b/preprocessing/hints.yaml
@@ -212,6 +212,13 @@ X-Men:
   type: "TV Show"
   release_year: "1992"
 
+# Week-specific entries for disambiguation  
+X-Men:
+  canonical_title: "X-Men"
+  type: "Movie"
+  release_year: "2000"
+  week: 200  # Example week number for movie
+
 # Movies
 3:10 to Yuma:
   canonical_title: "3:10 to Yuma"
@@ -237,6 +244,13 @@ Fargo:
   canonical_title: "Fargo"
   type: "Movie"
   release_year: "1996"
+
+# Week-specific entries for disambiguation
+Fargo:
+  canonical_title: "Fargo"
+  type: "TV Show"
+  release_year: "2014"
+  week: 150  # Example week number for TV show
 
 Hamilton:
   canonical_title: "Hamilton"

--- a/preprocessing/hints.yaml
+++ b/preprocessing/hints.yaml
@@ -14,21 +14,6 @@ BioShock:
   type: "Game"
   release_year: "2007"
 
-Black Widow:
-  canonical_title: "Black Widow"
-  type: "Game"
-  release_year: "1983"
-
-Die Hard:
-  canonical_title: "Die Hard"
-  type: "Game"
-  release_year: "1989"
-
-Endgame:
-  canonical_title: "Endgame"
-  type: "Game"
-  release_year: "2002"
-
 FF7:
   canonical_title: "Final Fantasy VII Remake"
   type: "Game"
@@ -37,11 +22,6 @@ Hades:
   canonical_title: "Hades"
   type: "Game"
   release_year: "2020"
-
-Kate:
-  canonical_title: "Kate"
-  type: "Game"
-  release_year: "2023"
 
 Prey:
   canonical_title: "Prey"
@@ -60,16 +40,6 @@ The Avengers:
 The Avengers w/ Danyi:
   canonical_title: "Marvel's Avengers"
   type: "Game"
-
-Top Gun:
-  canonical_title: "Top Gun"
-  type: "Game"
-  release_year: "1987"
-
-Zodiac:
-  canonical_title: "Zodiac"
-  type: "Game"
-  release_year: "2021"
 
 # Books
 Abaddon's Gate:
@@ -102,32 +72,6 @@ Don Quixote:
   type: "Book"
   release_year: "1600"
 
-Hamilton:
-  canonical_title: "Hamilton"
-  type: "Book"
-  release_year: "2016"
-
-Hidden Brain:
-  canonical_title: "The hidden brain"
-  type: "Book"
-  release_year: "2009"
-
-Losers:
-  canonical_title: "Losers"
-  type: "Book"
-  release_year: "2022"
-
-Midnight Mass:
-  canonical_title: "Midnight Mass"
-  type: "Book"
-  release_year: "2005"
-
-Off the Clock:
-  canonical_title: "Off the clock"
-  type: "Book"
-  release_year: "2018"
-
-
 Radical Candor:
   canonical_title: "Radical Candor"
   type: "Book"
@@ -141,7 +85,6 @@ Soon I Will Be Invincible:
   canonical_title: "Soon I Will Be Invincible"
   type: "Book"
   release_year: "2007"
-
 
 Sword of Destiny:
   canonical_title: "Sword of Destiny"
@@ -289,11 +232,6 @@ X-Men s2:
   type: "Movie"
   release_year: "2007"
 
-Barry:
-  canonical_title: "Barry"
-  type: "TV Show"
-  release_year: "2018"
-
 Black Monday:
   canonical_title: "Black Monday"
   type: "Movie"
@@ -303,11 +241,6 @@ Black Widow:
   canonical_title: "Black Widow"
   type: "Movie"
   release_year: "2021"
-
-Cowboy Bebop:
-  canonical_title: "Cowboy Bebop"
-  type: "TV Show"
-  release_year: "1998"
 
 Die Hard:
   canonical_title: "Die Hard"
@@ -324,10 +257,10 @@ Fargo:
   type: "Movie"
   release_year: "1996"
 
-Gentleman Jack:
-  canonical_title: "Gentleman Jack"
-  type: "TV Show"
-  release_year: "2019"
+Hamilton:
+  canonical_title: "Hamilton"
+  type: "Movie"
+  release_year: "2020"
 
 Jungle Cruise:
   canonical_title: "Jungle Cruise"
@@ -338,6 +271,11 @@ Kate:
   canonical_title: "Kate"
   type: "Movie"
   release_year: "2021"
+
+Losers:
+  canonical_title: "Losers"
+  type: "Movie"
+  release_year: "2022"
 
 Mortal Combat:
   canonical_title: "Mortal Kombat"
@@ -351,21 +289,6 @@ Nobody:
 No Time to Die:
   canonical_title: "No Time to Die"
   type: "Movie"
-  release_year: "2021"
-
-Midnight Mass:
-  canonical_title: "Midnight Mass"
-  type: "TV Show"
-  release_year: "2021"
-
-Moon Knight:
-  canonical_title: "Moon Knight"
-  type: "TV Show"
-  release_year: "2022"
-
-Only Murders in the Building:
-  canonical_title: "Only Murders in the Building"
-  type: "TV Show"
   release_year: "2021"
 
 Players:
@@ -382,16 +305,6 @@ Raising Arizona:
   canonical_title: "Raising Arizona"
   type: "Movie"
   release_year: "1987"
-
-Pieces of Her:
-  canonical_title: "Pieces of Her"
-  type: "TV Show"
-  release_year: "2022"
-
-Six Feet Under:
-  canonical_title: "Six Feet Under"
-  type: "TV Show"
-  release_year: "2001"
 
 Slow:
   canonical_title: "Slow"
@@ -428,30 +341,40 @@ The Eternals:
   type: "Movie"
   release_year: "2017"
 
+The Harder They Fall:
+  canonical_title: "The Harder They Fall"
+  type: "Movie"
+  release_year: "2021"
+
+The King's Man:
+  canonical_title: "The King's Man"
+  type: "Movie"
+  release_year: "2021"
+
 The Master:
   canonical_title: "The Master"
   type: "Movie"
   release_year: "2012"
 
-The Old Man:
-  canonical_title: "The Old Man"
+The Phantom Menace:
+  canonical_title: "Star Wars: Episode I – The Phantom Menace"
   type: "Movie"
-  release_year: "2019"
+  release_year: "1999"
+
+Tombstone:
+  canonical_title: "Tombstone"
+  type: "Movie"
+  release_year: "1993"
+
+Top Gun:
+  canonical_title: "Top Gun"
+  type: "Movie"
+  release_year: "1986"
 
 Uncharted:
   canonical_title: "Uncharted"
   type: "Movie"
   release_year: "2022"
-
-We Own This City:
-  canonical_title: "We Own This City"
-  type: "TV Show"
-  release_year: "2022"
-
-Yellowjackets:
-  canonical_title: "Yellowjackets"
-  type: "TV Show"
-  release_year: "2021"
 
 Zodiac:
   canonical_title: "Zodiac"

--- a/preprocessing/hints.yaml
+++ b/preprocessing/hints.yaml
@@ -78,7 +78,7 @@ Abaddon's Gate:
   release_year: "2013"
 
 Be Prepared:
-  canonical_title: "Be Prepared"
+  canonical_title: "Be Prepared: A Practical Handbook for New Dads"
   type: "Book"
   release_year: "2018"
 
@@ -127,10 +127,6 @@ Off the Clock:
   type: "Book"
   release_year: "2018"
 
-Pieces of Her:
-  canonical_title: "Pieces of Her"
-  type: "Book"
-  release_year: "2018"
 
 Radical Candor:
   canonical_title: "Radical Candor"
@@ -146,50 +142,22 @@ Soon I Will Be Invincible:
   type: "Book"
   release_year: "2007"
 
-Super Pumped:
-  canonical_title: "Super Pumped"
-  type: "Book"
-  release_year: "2019"
 
 Sword of Destiny:
   canonical_title: "Sword of Destiny"
   type: "Book"
   release_year: "2015"
 
-The Harder They Fall:
-  canonical_title: "The harder they fall"
-  type: "Book"
-  release_year: "1947"
-
-The King's Man:
-  canonical_title: "The King's Man"
-  type: "Book"
-  release_year: "2007"
-
 The Library of Babel:
   canonical_title: "The Library of Babel"
   type: "Book"
   release_year: "1991"
-
-The Phantom Menace:
-  canonical_title: "The Phantom Menace"
-  type: "Book"
-  release_year: "1999"
 
 Thinking Fast:
   canonical_title: "Thinking, fast and slow"
   type: "Book"
   release_year: "2011"
 
-Tombstone:
-  canonical_title: "Tombstone"
-  type: "Book"
-  release_year: "2020"
-
-We Own This City:
-  canonical_title: "We Own This City"
-  type: "Book"
-  release_year: "2021"
 
 # TV Shows
 Archer S1:
@@ -323,18 +291,33 @@ X-Men s2:
 
 Barry:
   canonical_title: "Barry"
-  type: "Movie"
-  release_year: "2016"
+  type: "TV Show"
+  release_year: "2018"
 
 Black Monday:
   canonical_title: "Black Monday"
   type: "Movie"
   release_year: "1988"
 
+Black Widow:
+  canonical_title: "Black Widow"
+  type: "Movie"
+  release_year: "2021"
+
 Cowboy Bebop:
   canonical_title: "Cowboy Bebop"
+  type: "TV Show"
+  release_year: "1998"
+
+Die Hard:
+  canonical_title: "Die Hard"
   type: "Movie"
-  release_year: "2001"
+  release_year: "1988"
+
+Endgame:
+  canonical_title: "Avengers: Endgame"
+  type: "Movie"
+  release_year: "2019"
 
 Fargo:
   canonical_title: "Fargo"
@@ -343,23 +326,18 @@ Fargo:
 
 Gentleman Jack:
   canonical_title: "Gentleman Jack"
-  type: "Movie"
-  release_year: "1999"
+  type: "TV Show"
+  release_year: "2019"
 
 Jungle Cruise:
   canonical_title: "Jungle Cruise"
   type: "Movie"
   release_year: "2021"
 
-Lois:
-  canonical_title: "Lois"
+Kate:
+  canonical_title: "Kate"
   type: "Movie"
-  release_year: "2012"
-
-Moon Knight:
-  canonical_title: "Moon Knight"
-  type: "Movie"
-  release_year: "2009"
+  release_year: "2021"
 
 Mortal Combat:
   canonical_title: "Mortal Kombat"
@@ -375,9 +353,19 @@ No Time to Die:
   type: "Movie"
   release_year: "2021"
 
+Midnight Mass:
+  canonical_title: "Midnight Mass"
+  type: "TV Show"
+  release_year: "2021"
+
+Moon Knight:
+  canonical_title: "Moon Knight"
+  type: "TV Show"
+  release_year: "2022"
+
 Only Murders in the Building:
   canonical_title: "Only Murders in the Building"
-  type: "Movie"
+  type: "TV Show"
   release_year: "2021"
 
 Players:
@@ -395,10 +383,15 @@ Raising Arizona:
   type: "Movie"
   release_year: "1987"
 
+Pieces of Her:
+  canonical_title: "Pieces of Her"
+  type: "TV Show"
+  release_year: "2022"
+
 Six Feet Under:
   canonical_title: "Six Feet Under"
-  type: "Movie"
-  release_year: "2023"
+  type: "TV Show"
+  release_year: "2001"
 
 Slow:
   canonical_title: "Slow"
@@ -450,15 +443,20 @@ Uncharted:
   type: "Movie"
   release_year: "2022"
 
-We Own this City:
+We Own This City:
   canonical_title: "We Own This City"
-  type: "Movie"
+  type: "TV Show"
   release_year: "2022"
 
 Yellowjackets:
   canonical_title: "Yellowjackets"
-  type: "Movie"
+  type: "TV Show"
   release_year: "2021"
+
+Zodiac:
+  canonical_title: "Zodiac"
+  type: "Movie"
+  release_year: "2007"
 
 # Other
 Ant Design:
@@ -476,4 +474,8 @@ Bald Move - Fargo:
 MSF Doom Raids:
   type: "Ignored"
 MSF DD4 (run 1):
+  type: "Ignored"
+Hidden Brain:
+  type: "Ignored"
+Off the Clock:
   type: "Ignored"

--- a/preprocessing/hints.yaml
+++ b/preprocessing/hints.yaml
@@ -232,11 +232,6 @@ X-Men s2:
   type: "Movie"
   release_year: "2007"
 
-Black Monday:
-  canonical_title: "Black Monday"
-  type: "Movie"
-  release_year: "1988"
-
 Black Widow:
   canonical_title: "Black Widow"
   type: "Movie"
@@ -275,7 +270,7 @@ Kate:
 Losers:
   canonical_title: "Losers"
   type: "Movie"
-  release_year: "2022"
+  release_year: "2019"
 
 Mortal Combat:
   canonical_title: "Mortal Kombat"
@@ -337,9 +332,9 @@ The Big Lebowski:
   release_year: "1998"
 
 The Eternals:
-  canonical_title: "The Eternals"
+  canonical_title: "Eternals"
   type: "Movie"
-  release_year: "2017"
+  release_year: "2021"
 
 The Harder They Fall:
   canonical_title: "The Harder They Fall"

--- a/preprocessing/tests/conftest.py
+++ b/preprocessing/tests/conftest.py
@@ -25,3 +25,18 @@ def sample_hints():
             },
         },
     }
+
+
+@pytest.fixture()
+def sample_multi_match_hints():
+    """Sample multi-match hints data for testing."""
+    return {
+        "Fargo": [
+            {"canonical_title": "Fargo", "type": "Movie", "dates": ["2021-02-03"]},
+            {
+                "canonical_title": "Fargo",
+                "type": "TV Show",
+                "dates": ["2023-10-23"],
+            },
+        ]
+    }

--- a/preprocessing/tests/test_media_tagger.py
+++ b/preprocessing/tests/test_media_tagger.py
@@ -701,3 +701,124 @@ def test_combine_similar_entries_edge_cases(caplog):
     # Dates should be combined
     assert ff7_entry["started_dates"] == ["2023-01-01"]
     assert ff7_entry["finished_dates"] == ["2023-02-01"]
+
+
+def test_week_based_hint_matching(setup_hints_mock, setup_api_mocks):
+    """Test that hints with week specifications only match entries from those weeks."""
+    # Setup hint with week specification
+    setup_hints_mock({
+        "Fargo": {
+            "canonical_title": "Fargo",
+            "type": "TV Show", 
+            "week": 150
+        }
+    })
+    setup_api_mocks(movie_response=[], tv_response=[], game_response=[], book_response=[])
+    
+    # Entry that spans multiple weeks, only one matches hint
+    entry = {
+        "title": "Fargo",
+        "started_dates": ["2022-11-07"],  # Week 150 (assuming 2020-01-01 as min_date)
+        "finished_dates": ["2022-11-21"]  # Week 152
+    }
+    
+    tagged_entries = apply_tagging([entry])
+    
+    # Should result in 2 entries - one matching hint, one not
+    assert len(tagged_entries) == 2
+    
+    # Find the entries
+    tv_entry = next((e for e in tagged_entries if e["tagged"]["type"] == "TV Show"), None)
+    fallback_entry = next((e for e in tagged_entries if e["tagged"]["type"] == "Other / Unknown"), None)
+    
+    assert tv_entry is not None
+    assert fallback_entry is not None
+    assert tv_entry["canonical_title"] == "Fargo"
+    assert fallback_entry["canonical_title"] == "Fargo"
+
+
+def test_week_based_hint_no_split_needed(setup_hints_mock, setup_api_mocks):
+    """Test that entries don't get split when all weeks match the hint."""
+    # Setup hint with week specification
+    setup_hints_mock({
+        "Fargo": {
+            "canonical_title": "Fargo",
+            "type": "TV Show",
+            "week": 150
+        }
+    })
+    setup_api_mocks(tv_response=[{
+        "canonical_title": "Fargo",
+        "type": "TV Show",
+        "tags": {"genre": ["Drama"]},
+        "confidence": 0.9,
+        "source": "tmdb"
+    }])
+    
+    # Entry that only has dates in the matching week
+    entry = {
+        "title": "Fargo",
+        "started_dates": ["2022-11-07"],  # Week 150
+        "finished_dates": ["2022-11-07"]  # Same week
+    }
+    
+    tagged_entries = apply_tagging([entry])
+    
+    # Should result in 1 entry
+    assert len(tagged_entries) == 1
+    assert tagged_entries[0]["tagged"]["type"] == "TV Show"
+    assert tagged_entries[0]["canonical_title"] == "Fargo"
+
+
+def test_entry_splitting_warning(caplog, setup_hints_mock, setup_api_mocks):
+    """Test that a warning is logged when entries are split due to week-specific hints."""
+    setup_hints_mock({
+        "X-Men": {
+            "canonical_title": "X-Men",
+            "type": "Movie",
+            "week": 200
+        }
+    })
+    setup_api_mocks(movie_response=[], tv_response=[], game_response=[], book_response=[])
+    
+    entry = {
+        "title": "X-Men",
+        "started_dates": ["2023-10-30"],  # Week 200
+        "finished_dates": ["2023-11-13"]  # Week 202
+    }
+    
+    with caplog.at_level(logging.WARNING):
+        apply_tagging([entry])
+    
+    assert "Splitting entry 'X-Men'" in caplog.text
+    assert "hint with week 200 only applies to some weeks" in caplog.text
+
+
+def test_no_week_hint_fallback(setup_hints_mock, setup_api_mocks):
+    """Test that hints without week specifications work as before."""
+    setup_hints_mock({
+        "The Hobbit": {
+            "canonical_title": "The Hobbit",
+            "type": "Book"
+        }
+    })
+    setup_api_mocks(book_response=[{
+        "canonical_title": "The Hobbit",
+        "type": "Book",
+        "tags": {"genre": ["Fantasy"]},
+        "confidence": 1.0,
+        "source": "openlibrary"
+    }])
+    
+    entry = {
+        "title": "The Hobbit",
+        "started_dates": ["2023-01-01"],
+        "finished_dates": ["2023-02-01"]
+    }
+    
+    tagged_entries = apply_tagging([entry])
+    
+    # Should work normally without splitting
+    assert len(tagged_entries) == 1
+    assert tagged_entries[0]["tagged"]["type"] == "Book"
+    assert tagged_entries[0]["canonical_title"] == "The Hobbit"


### PR DESCRIPTION
In some cases a title used in the raw entries will represent 2 separate media entries.  For these cases, let's allow adding a `dates` value to a hint.  If an entry matches a hint with a `dates` field, but only some of it's dates match the hint, then split it into separate entries and warn.  Some examples of this case are `Fargo` and `Dark Matter`